### PR TITLE
Clarify HOD and HO-DET proof boundary

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,17 +2,21 @@
 
 ## Current Milestone
 
-First proof chain record created for HOD-001.
+HOD-001 baseline has separate validation/proof artifacts.
+
+HO-DET-001 successor proof record exists and is currently SOURCE_EXISTS only.
 
 ## Next Gate
 
-Add second proof record from a new detection-validation chain and begin release-bundle indexing.
+Next gate for HO-DET-001 is static review and validation planning, not runtime, signal, evidence linkage, or public-safe promotion.
 
 ## Baseline Integrity Check Scope
 
 - Current check coverage: HOD-001 baseline proof record schema/integrity + required baseline proof artifact paths in this repository.
 - Not yet covered: non-baseline families, detection correctness, validation semantic truth, generalized cross-family proof maturity.
+- HOD-001 artifacts may inform HO-DET-001 review, but they do not validate or promote HO-DET-001.
 
 ## Blocking Risks
 
 - Proof ledger `sha256` currently tracks validation report hash; add proof-packet hash convention for future entries.
+- Do not use HOD-001 proof as HO-DET-001 proof.

--- a/docs/ID_BOUNDARY.md
+++ b/docs/ID_BOUNDARY.md
@@ -1,0 +1,30 @@
+# HOD-001 / HO-DET-001 Boundary
+
+## Purpose
+
+This note prevents drift between the HOD-001 baseline proof chain and the HO-DET-001 successor detection ID.
+
+## Boundary
+
+HOD-001 is a baseline, legacy, or reference proof chain.
+
+HO-DET-001 is the successor governed detection ID.
+
+HOD-001 artifacts may inform review, but they do not validate or promote HO-DET-001.
+
+HO-DET-001 currently remains SOURCE_EXISTS. Its next gate is static review and validation planning.
+
+## Allowed Wording
+
+- "HOD-001 baseline artifacts may inform HO-DET-001 review."
+- "HO-DET-001 source exists."
+- "HO-DET-001 requires static review and validation planning before promotion."
+
+## Blocked Wording
+
+- "HOD-001 validates HO-DET-001."
+- "HO-DET-001 is validated."
+- "HO-DET-001 is runtime-active."
+- "HO-DET-001 has observed signal."
+- "HO-DET-001 is evidence-linked."
+- "HO-DET-001 is PUBLIC_SAFE."


### PR DESCRIPTION
This PR clarifies the boundary between HOD-001 baseline proof artifacts and the HO-DET-001 successor detection ID.

Changes:
- Updates STATUS.md.
- Adds docs/ID_BOUNDARY.md.

Claim boundaries:
- HOD-001 is baseline/reference proof material.
- HO-DET-001 is the successor governed detection ID.
- HOD-001 artifacts may inform review but do not validate or promote HO-DET-001.
- HO-DET-001 remains SOURCE_EXISTS.
- Static review and validation planning remain the next gates.