### PR TITLE
Record HO-DET-001 synthetic validation proof

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -4,11 +4,11 @@
 
 HOD-001 baseline has separate validation/proof artifacts.
 
-HO-DET-001 successor proof record exists and is currently SOURCE_EXISTS only.
+HO-DET-001 successor proof record now records merged synthetic validation proof at TEST_VALIDATED_SYNTHETIC_SCOPE.
 
 ## Next Gate
 
-Next gate for HO-DET-001 is static review and validation planning, not runtime, signal, evidence linkage, or public-safe promotion.
+Next gate for HO-DET-001 is runtime deployment evidence or preserved signal evidence, not website, LinkedIn, or public-safe promotion.
 
 ## Baseline Integrity Check Scope
 
@@ -20,3 +20,4 @@ Next gate for HO-DET-001 is static review and validation planning, not runtime, 
 
 - Proof ledger `sha256` currently tracks validation report hash; add proof-packet hash convention for future entries.
 - Do not use HOD-001 proof as HO-DET-001 proof.
+- HO-DET-001 synthetic validation proof does not support runtime-active, signal-observed, public-safe, production-ready, live Splunk, Cribl-routed telemetry, Wazuh live collection, production AutoSOC triage, analyst-approved disposition, HO-GPU-01 runtime-active, or AI-decided disposition claims.

--- a/docs/ID_BOUNDARY.md
+++ b/docs/ID_BOUNDARY.md
@@ -12,19 +12,34 @@ HO-DET-001 is the successor governed detection ID.
 
 HOD-001 artifacts may inform review, but they do not validate or promote HO-DET-001.
 
-HO-DET-001 currently remains SOURCE_EXISTS. Its next gate is static review and validation planning.
+After the merged detections and validation PRs, HO-DET-001 may be described as TEST_VALIDATED_SYNTHETIC_SCOPE only.
+
+The supported validation is synthetic fixture validation only. It does not prove runtime-active status, signal-observed status, public-safe status, production readiness, live Splunk firing, Cribl-routed telemetry, Wazuh live collection, HO-GPU-01 runtime activity, or AI-decided disposition.
+
+Evidence-linked status beyond the recorded synthetic validation artifacts remains blocked unless explicitly recorded in a proof record and evidence ledger entry.
 
 ## Allowed Wording
 
 - "HOD-001 baseline artifacts may inform HO-DET-001 review."
 - "HO-DET-001 source exists."
-- "HO-DET-001 requires static review and validation planning before promotion."
+- "HO-DET-001 passed synthetic validation against controlled positive and negative process-creation fixtures."
+- "HO-DET-001 is TEST_VALIDATED_SYNTHETIC_SCOPE."
+- "HO-DET-001 requires runtime and signal evidence before runtime-active or signal-observed promotion."
 
 ## Blocked Wording
 
 - "HOD-001 validates HO-DET-001."
-- "HO-DET-001 is validated."
+- "HOD-001 promotes HO-DET-001."
+- "V1 proof promotes V2."
+- "HO-DET-001 is validated beyond synthetic fixture scope."
 - "HO-DET-001 is runtime-active."
 - "HO-DET-001 has observed signal."
-- "HO-DET-001 is evidence-linked."
+- "HO-DET-001 is evidence-linked beyond synthetic validation artifacts."
 - "HO-DET-001 is PUBLIC_SAFE."
+- "HO-DET-001 is production-ready."
+- "Live Splunk fired for HO-DET-001."
+- "Cribl routed HO-DET-001 telemetry."
+- "Wazuh collected live HO-DET-001 telemetry."
+- "HO-GPU-01 is runtime-active for HO-DET-001."
+- "AI decided the HO-DET-001 disposition."
+- "The website proves HO-DET-001 status."

--- a/evidence/evidence-ledger.json
+++ b/evidence/evidence-ledger.json
@@ -1,7 +1,7 @@
 {
   "ledger_version": "1.0.0",
   "repository": "hawkinsoperations-proof",
-  "generated_at": "2026-04-21T11:10:31-05:00",
+  "generated_at": "2026-04-29T11:09:22-05:00",
   "entries": [
     {
       "id": "PROOF-HOD-001-2026-04-21-001",

--- a/evidence/evidence-ledger.json
+++ b/evidence/evidence-ledger.json
@@ -19,6 +19,26 @@
       "sha256": "b919006a124f241b1a8dbbfa2c25e2d3a4dceb06adde1d2ecaaf2bfdd9fafc81",
       "source_ref": "HOD-001",
       "notes": "Claim boundary: baseline harness pass, not a production efficacy claim."
+    },
+    {
+      "id": "HO-DET-001-SYNTHETIC-VALIDATION-001",
+      "timestamp": "2026-04-29T11:09:22-05:00",
+      "type": "synthetic_validation_record",
+      "summary": "HO-DET-001 merged synthetic validation proof recording 14 of 14 controlled cases passed with 7 matched positives, no missed positives, and no false-positive negative cases.",
+      "artifact_paths": [
+        "proof/records/HO-DET-001-SYNTHETIC-VALIDATION-001.json",
+        "proof/records/HO-DET-001.md",
+        "hawkinsoperations-detections/detections/successor/ho-det-001/rule.yml",
+        "hawkinsoperations-detections/detections/successor/ho-det-001/splunk.spl",
+        "hawkinsoperations-validation/validation/successor/ho-det-001/validation-cases.json",
+        "hawkinsoperations-validation/reports/ho-det-001/validation-result.json",
+        "hawkinsoperations-validation/reports/ho-det-001/validation-result.md",
+        "hawkinsoperations-validation/validation/successor/ho-det-001/autosoc-triage-packet.json",
+        "hawkinsoperations-validation/validation/successor/ho-det-001/llm-summary.json"
+      ],
+      "sha256": "e7b2ded33c3a26a6dd53ea6500fb9fba37a42c977fbfe70d927e931f41839561",
+      "source_ref": "HO-DET-001",
+      "notes": "Synthetic validation scope only; not runtime-active, not signal-observed, not public-safe."
     }
   ]
 }

--- a/proof/records/HO-DET-001-SYNTHETIC-VALIDATION-001.json
+++ b/proof/records/HO-DET-001-SYNTHETIC-VALIDATION-001.json
@@ -1,0 +1,63 @@
+{
+  "id": "HO-DET-001-SYNTHETIC-VALIDATION-001",
+  "detection_id": "HO-DET-001",
+  "proof_type": "synthetic_validation_record",
+  "status": "TEST_VALIDATED_SYNTHETIC_SCOPE",
+  "created_at": "2026-04-29T11:09:22-05:00",
+  "source_refs": {
+    "detections_merge_commit": "13a74f812fd17027b4a1968b615a4aae78c99f51",
+    "validation_merge_commit": "e3bcf6c087b8e22ea62c08438fae6a60e800b094",
+    "artifact_paths": [
+      "hawkinsoperations-detections/detections/successor/ho-det-001/rule.yml",
+      "hawkinsoperations-detections/detections/successor/ho-det-001/splunk.spl",
+      "hawkinsoperations-validation/validation/successor/ho-det-001/validation-cases.json",
+      "hawkinsoperations-validation/reports/ho-det-001/validation-result.json",
+      "hawkinsoperations-validation/reports/ho-det-001/validation-result.md",
+      "hawkinsoperations-validation/validation/successor/ho-det-001/autosoc-triage-packet.json",
+      "hawkinsoperations-validation/validation/successor/ho-det-001/llm-summary.json",
+      "hawkinsoperations-validation/scripts/validate-ho-det-001.py",
+      "hawkinsoperations-validation/scripts/autosoc-triage-ho-det-001.py",
+      "hawkinsoperations-validation/scripts/offline-llm-summary-ho-det-001.py"
+    ]
+  },
+  "supported_claim": "HO-DET-001 passed synthetic validation against controlled positive and negative process-creation fixtures.",
+  "unsupported_claims": [
+    "runtime-active",
+    "signal-observed",
+    "public-safe",
+    "production-ready",
+    "live Splunk fired",
+    "Cribl-routed telemetry",
+    "Wazuh live collection",
+    "production AutoSOC triage",
+    "analyst-approved disposition",
+    "HO-GPU-01 runtime-active",
+    "AI-decided disposition"
+  ],
+  "validation_summary": {
+    "status": "pass",
+    "total_cases": 14,
+    "matched_positive_count": 7,
+    "missed_positive_cases": [],
+    "false_positive_negative_cases": []
+  },
+  "autosoc_summary": {
+    "packet_id": "HO-DET-001-SYNTHETIC-TRIAGE-001",
+    "scope": "deterministic synthetic output only",
+    "not_production_autosoc": true
+  },
+  "llm_summary": {
+    "model_runtime_status": "BLOCKED",
+    "execution_mode": "deterministic_stub_no_model_call",
+    "hypothesis_support_only": true
+  },
+  "public_safe_status": "NOT_PUBLIC_SAFE",
+  "approval_status": "NOT_APPROVED",
+  "notes": [
+    "Synthetic validation only.",
+    "No runtime or signal evidence.",
+    "No public-safe promotion.",
+    "AutoSOC packet is deterministic synthetic output only.",
+    "Offline LLM summary is a blocked-runtime deterministic stub."
+  ]
+}

--- a/proof/records/HO-DET-001.md
+++ b/proof/records/HO-DET-001.md
@@ -1,221 +1,163 @@
-# HO-DET-001 — Suspicious PowerShell EncodedCommand Execution via Sysmon Event ID 1
+# HO-DET-001 - Suspicious PowerShell EncodedCommand Execution via Sysmon Event ID 1
 
 ## Header
 
 - Detection ID: HO-DET-001
-- Detection title: HO-DET-001 — Suspicious PowerShell EncodedCommand Execution via Sysmon Event ID 1
-- Proof packet status: SOURCE_EXISTS as a draft record in the proof repo
-- Current proof level: 1 SOURCE_EXISTS
-- Current trust class: SOURCE_EXISTS
+- Detection title: HO-DET-001 - Suspicious PowerShell EncodedCommand Execution via Sysmon Event ID 1
+- Proof packet status: TEST_VALIDATED_SYNTHETIC_SCOPE recorded in the proof repo
+- Current proof level: TEST_VALIDATED_SYNTHETIC_SCOPE
+- Current trust class: TEST_VALIDATED_SYNTHETIC_SCOPE
 - Public-safe status: NOT_PUBLIC_SAFE
 - Approval status: NOT_APPROVED
 
-This packet is a governed proof-lifecycle demonstration showing how HawkinsOperations separates source, validation, runtime, signal, evidence, and public claims before promoting a detection. It is not a novelty claim and does not assert end-to-end detection proof.
+This packet records merged synthetic validation evidence for HO-DET-001. It does not assert runtime activity, observed signal, production deployment, public-safe status, or live SOC operation.
 
 ## Status Clarification
 
-- Proof packet status: SOURCE_EXISTS as a draft record in the proof repo.
-- Detection proof level: 1 SOURCE_EXISTS.
-- Detection trust class: SOURCE_EXISTS.
+- Proof packet status: TEST_VALIDATED_SYNTHETIC_SCOPE.
+- Detection proof level: TEST_VALIDATED_SYNTHETIC_SCOPE.
+- Detection trust class: TEST_VALIDATED_SYNTHETIC_SCOPE.
 - Canonical detection source: `hawkinsoperations-detections/detections/successor/ho-det-001/rule.yml`.
-- Canonical validation path: UNKNOWN.
-- Runtime-active status: UNKNOWN.
-- Signal-observed status: UNKNOWN.
-- Evidence-linked status: UNKNOWN.
+- Canonical Splunk source: `hawkinsoperations-detections/detections/successor/ho-det-001/splunk.spl`.
+- Canonical validation path: `hawkinsoperations-validation/reports/ho-det-001/validation-result.json`.
+- Synthetic proof record: `proof/records/HO-DET-001-SYNTHETIC-VALIDATION-001.json`.
+- Runtime-active status: BLOCKED.
+- Signal-observed status: BLOCKED.
+- Evidence-linked status: BLOCKED for runtime or signal evidence; this packet links synthetic validation artifacts only.
 - Public-safe status: NOT_PUBLIC_SAFE.
 - Approval status: NOT_APPROVED.
 
-The proof packet itself exists as a draft proof packet. The canonical HO-DET-001 source artifact exists in the detection source repository. Related HOD-001 encoded-command artifacts may inform future review, but they are not HO-DET-001 truth. Current detection proof level is limited to SOURCE_EXISTS until static review, validation, runtime, signal, evidence-linkage, and public-safe gates are satisfied.
+Related HOD-001 encoded-command artifacts may inform review, but they are not HO-DET-001 truth. V1 artifacts do not promote V2 status.
 
-## Detection identity
+## Linked Artifacts
 
-- Detection ID: HO-DET-001
-- Detection title: HO-DET-001 — Suspicious PowerShell EncodedCommand Execution via Sysmon Event ID 1
-- Threat behavior: PowerShell or pwsh process execution using encoded command flags or encoded payload patterns.
-- Data source: Windows process creation telemetry, expected Sysmon Event ID 1 when available.
-- Backend target: UNKNOWN; expected targets may include SIEM/search or detection backend after source owner defines implementation.
-- MITRE mapping if known: INFERRED candidate mapping to Command and Scripting Interpreter: PowerShell (T1059.001). This is not promoted for HO-DET-001 until source and review exist under successor proof rules.
-- Source owner repo: hawkinsoperations-detections
-- Validation owner repo: hawkinsoperations-validation
-- Proof owner repo: hawkinsoperations-proof
-- Public rendering owner: hawkinsoperations-website
+- `hawkinsoperations-detections/detections/successor/ho-det-001/rule.yml`
+- `hawkinsoperations-detections/detections/successor/ho-det-001/splunk.spl`
+- `hawkinsoperations-validation/validation/successor/ho-det-001/validation-cases.json`
+- `hawkinsoperations-validation/reports/ho-det-001/validation-result.json`
+- `hawkinsoperations-validation/reports/ho-det-001/validation-result.md`
+- `hawkinsoperations-validation/validation/successor/ho-det-001/autosoc-triage-packet.json`
+- `hawkinsoperations-validation/validation/successor/ho-det-001/llm-summary.json`
 
-## Current truth table
+## Source Refs
+
+- Detections merge commit: `13a74f812fd17027b4a1968b615a4aae78c99f51`
+- Validation merge commit: `e3bcf6c087b8e22ea62c08438fae6a60e800b094`
+
+## Supported Claim
+
+"HO-DET-001 passed synthetic validation against controlled positive and negative process-creation fixtures."
+
+## Unsupported Claims
+
+- runtime-active
+- signal-observed
+- public-safe
+- production-ready
+- live Splunk fired
+- Cribl-routed telemetry
+- Wazuh live collection
+- production AutoSOC triage
+- analyst-approved disposition
+- HO-GPU-01 runtime-active
+- AI-decided disposition
+
+## Current Truth Table
 
 | Claim | Truth label | Evidence/reference | Allowed wording | Blocked wording | Next promotion gate |
 |---|---|---|---|---|---|
-| HO-DET-001 proof packet exists in the proof repo. | PROVEN | proof/records/HO-DET-001.md | "A draft proof packet exists for HO-DET-001." | "The detection is proven." | Identify source path and owner review. |
-| HO-DET-001 detection source exists. | PROVEN | hawkinsoperations-detections/detections/successor/ho-det-001/rule.yml | "Detection source exists for HO-DET-001." | "The detection is active." | Static review against source and rule contract. |
-| A related encoded-command baseline exists under HOD-001. | INFERRED | Read-only search found HOD-001 encoded-command artifacts in related repos. | "Related HOD-001 artifacts may inform review but do not automatically become HO-DET-001 truth." | "HOD-001 is HO-DET-001." | Reclassify or map through successor governance. |
-| HO-DET-001 static review has passed. | UNKNOWN | No static review record for HO-DET-001 found. | "Static review is required." | "This passed static validation." | Static review against source and rule contract. |
-| HO-DET-001 test definition exists. | UNKNOWN | No HO-DET-001 validation plan found in related validation repo. | "Validation plan is not yet proven for HO-DET-001." | "A validation plan is defined." | Create or identify positive and negative tests. |
-| HO-DET-001 validation result exists. | UNKNOWN | No HO-DET-001 validation result found. | "Validation result is not yet proven for HO-DET-001." | "The detection passed validation." | Run validation and preserve output. |
-| HO-DET-001 runtime-active status is proven. | UNKNOWN | No deployment, enablement, schedule, or backend state evidence linked. | "Runtime-active status requires deployment evidence." | "This detection is active." | Preserve runtime deployment evidence. |
-| HO-DET-001 signal-observed status is proven. | UNKNOWN | No preserved telemetry, alert, log, or search output linked. | "Signal-observed status requires preserved telemetry, alert, log, or search output." | "This catches attacks." | Preserve signal observation evidence. |
-| HO-DET-001 evidence-linked status is proven. | UNKNOWN | This packet contains no promoted evidence item linking source, validation, runtime, or signal. | "Evidence linkage is pending." | "HO-DET-001 is evidence-linked." | Add reviewed evidence item IDs and claim linkage. |
+| HO-DET-001 proof packet exists in the proof repo. | PROVEN | `proof/records/HO-DET-001.md` | "A proof packet exists for HO-DET-001." | "The detection is production proven." | Keep proof current as gates change. |
+| HO-DET-001 detection source exists. | PROVEN | `hawkinsoperations-detections/detections/successor/ho-det-001/rule.yml` | "Detection source exists for HO-DET-001." | "The detection is active." | Runtime deployment evidence. |
+| HO-DET-001 Splunk source exists. | PROVEN | `hawkinsoperations-detections/detections/successor/ho-det-001/splunk.spl` at merge commit `13a74f812fd17027b4a1968b615a4aae78c99f51` | "A Splunk SPL source artifact exists for HO-DET-001." | "Live Splunk fired." | Deploy and preserve runtime/search evidence. |
+| HO-DET-001 synthetic validation passed. | PROVEN | `hawkinsoperations-validation/reports/ho-det-001/validation-result.json` at merge commit `e3bcf6c087b8e22ea62c08438fae6a60e800b094` | "HO-DET-001 passed synthetic validation against controlled positive and negative process-creation fixtures." | "This catches attacks." | Runtime and signal evidence. |
+| AutoSOC synthetic triage packet exists. | PROVEN | `hawkinsoperations-validation/validation/successor/ho-det-001/autosoc-triage-packet.json` | "A deterministic synthetic triage packet was generated from the validation result." | "Production AutoSOC triage occurred." | Production AutoSOC run evidence. |
+| Offline LLM support stub exists. | PROVEN | `hawkinsoperations-validation/validation/successor/ho-det-001/llm-summary.json` | "A deterministic blocked-runtime LLM support stub exists." | "HO-GPU-01 was runtime-active." | Approved local model runtime evidence. |
+| HO-DET-001 runtime-active status is proven. | BLOCKED | No deployment, enablement, schedule, or backend state evidence linked. | "Runtime-active status requires deployment evidence." | "This detection is active." | Preserve runtime deployment evidence. |
+| HO-DET-001 signal-observed status is proven. | BLOCKED | No preserved telemetry, alert, log, or search output linked. | "Signal-observed status requires preserved telemetry, alert, log, or search output." | "This catches attacks." | Preserve signal observation evidence. |
 | HO-DET-001 public-safe status is approved. | BLOCKED | No reviewed public wording, privacy review, stale review, evidence linkage, or Raylee approval. | "Public-safe status requires reviewed wording, privacy review, stale review, evidence linkage, and Raylee approval." | "HO-DET-001 is PUBLIC_SAFE." | Raylee approval after evidence and claim review. |
 
-## Proof level assessment
+## Validation Summary
 
-### 0 IDEA
+- Validation status: pass
+- Total controlled cases: 14
+- Matched positive count: 7
+- Missed positive cases: none
+- False-positive negative cases: none
+- Validation scope: synthetic process-creation fixtures only
+- Validation result path: `hawkinsoperations-validation/reports/ho-det-001/validation-result.json`
+
+## AutoSOC Summary
+
+- Packet ID: HO-DET-001-SYNTHETIC-TRIAGE-001
+- Scope: deterministic synthetic output only
+- Production AutoSOC status: BLOCKED
+- Analyst-approved disposition: BLOCKED
+
+## LLM Summary
+
+- Model runtime status: BLOCKED
+- Execution mode: deterministic_stub_no_model_call
+- Summary type: hypothesis_triage_support_only
+- AI-decided disposition: BLOCKED
+
+## Proof Level Assessment
+
+### SOURCE_EXISTS
 
 - Status: SATISFIED
-- Evidence required: Detection identity and intended proof-lifecycle scope.
-- Current evidence: This proof packet defines HO-DET-001 as a governed proof-lifecycle demonstration.
-- Promotion gate: Identify canonical source in hawkinsoperations-detections.
-- Blocked claim if not satisfied: "This detection has source."
+- Evidence: `hawkinsoperations-detections/detections/successor/ho-det-001/rule.yml` and `hawkinsoperations-detections/detections/successor/ho-det-001/splunk.spl`.
 
-### 1 SOURCE_EXISTS
+### TEST_DEFINED
+
+- Status: SATISFIED for synthetic scope
+- Evidence: `hawkinsoperations-validation/validation/successor/ho-det-001/validation-cases.json`.
+
+### TEST_VALIDATED_SYNTHETIC_SCOPE
 
 - Status: SATISFIED
-- Evidence required: Canonical source file path, source owner repo, commit or stable reference, and source review context.
-- Current evidence: `hawkinsoperations-detections/detections/successor/ho-det-001/rule.yml`.
-- Promotion gate: Complete static review against the source artifact and rule contract.
-- Blocked claim if not satisfied: "Detection source exists."
+- Evidence: `hawkinsoperations-validation/reports/ho-det-001/validation-result.json`.
+- Supported claim: "HO-DET-001 passed synthetic validation against controlled positive and negative process-creation fixtures."
 
-### 2 STATIC_VALIDATED
+### RUNTIME_ACTIVE
 
 - Status: NOT_SATISFIED
-- Evidence required: Static review record showing structural coherence, expected fields, ATT&CK mapping review if used, data source assumptions, and backend compatibility.
-- Current evidence: UNKNOWN; no HO-DET-001 static review record linked.
-- Promotion gate: Complete static review after source exists.
-- Blocked claim if not satisfied: "This passed static review."
+- Evidence required: deployment or enablement proof, backend/platform identifier sanitized for public use, timestamp, owner, currentness review, and stale review date.
 
-### 3 TEST_DEFINED
+### SIGNAL_OBSERVED
 
 - Status: NOT_SATISFIED
-- Evidence required: Positive and negative test cases, expected match behavior, expected non-match behavior, and validation owner path.
-- Current evidence: UNKNOWN; no HO-DET-001 validation plan linked.
-- Promotion gate: Define validation cases in hawkinsoperations-validation.
-- Blocked claim if not satisfied: "A validation check is defined."
+- Evidence required: preserved telemetry, alert, log, or search output showing the signal, with context, time window, query or rule reference, and redaction review.
 
-### 4 TEST_VALIDATED
-
-- Status: NOT_SATISFIED
-- Evidence required: Recorded validation execution result, timestamp, owner, environment, pass/fail output, and preserved result path.
-- Current evidence: UNKNOWN; no HO-DET-001 validation result linked.
-- Promotion gate: Run validation and preserve output.
-- Blocked claim if not satisfied: "This passed validation."
-
-### 5 RUNTIME_ACTIVE
-
-- Status: NOT_SATISFIED
-- Evidence required: Deployment or enablement proof, backend/platform identifier sanitized for public use, timestamp, owner, currentness review, and stale review date.
-- Current evidence: UNKNOWN; no runtime evidence linked.
-- Promotion gate: Preserve deployment evidence from platform owner.
-- Blocked claim if not satisfied: "This detection is active."
-
-### 6 SIGNAL_OBSERVED
-
-- Status: NOT_SATISFIED
-- Evidence required: Preserved telemetry, alert, log, or search output showing the signal, with context, time window, query or rule reference, and redaction review.
-- Current evidence: UNKNOWN; no signal evidence linked.
-- Promotion gate: Preserve signal observation and context.
-- Blocked claim if not satisfied: "This catches attacks" or "A signal was observed."
-
-### 7 EVIDENCE_LINKED
-
-- Status: NOT_SATISFIED
-- Evidence required: Evidence item IDs, evidence owner, artifact path or redacted reference, supported claim, unsupported claim, privacy status, stale review status, and promotion status.
-- Current evidence: UNKNOWN; no evidence item is promoted for HO-DET-001.
-- Promotion gate: Link reviewed source, validation, runtime, and signal evidence as available.
-- Blocked claim if not satisfied: "HO-DET-001 is evidence-linked."
-
-### 8 PUBLIC_SAFE
+### PUBLIC_SAFE
 
 - Status: BLOCKED
-- Evidence required: Approved claim text, evidence path, trust class, allowed wording, blocked wording, stale review date, privacy review, public claim review, and Raylee approval.
-- Current evidence: No approval evidence exists in this packet.
-- Promotion gate: Raylee approval after evidence linkage and public-safe review.
-- Blocked claim if not satisfied: "HO-DET-001 is PUBLIC_SAFE."
+- Evidence required: approved claim text, evidence path, trust class, allowed wording, blocked wording, stale review date, privacy review, public claim review, and Raylee approval.
 
-## Trust class assessment
+## Allowed Claims
 
-- Current trust class: SOURCE_EXISTS
-- Reason: The proof packet exists and the canonical source path is identified, but static validation, test definition, test result, runtime evidence, signal observation, evidence linkage, and public approval are not proven for HO-DET-001.
-- What would promote it: A logged static review against the canonical source and rule contract could promote the detection claim to STATIC_VALIDATED.
-- What would block promotion: Missing source path, missing owner, private or unsafe details, stale or unreviewed evidence, unlogged changes, or any attempt to self-promote through AI output.
+- "HO-DET-001 has merged source artifacts in the detections repository."
+- "HO-DET-001 has merged synthetic validation artifacts in the validation repository."
+- "HO-DET-001 passed synthetic validation against controlled positive and negative process-creation fixtures."
+- "A deterministic synthetic AutoSOC triage packet was generated from the HO-DET-001 synthetic validation result."
+- "The offline LLM support artifact is a deterministic blocked-runtime stub and does not prove HO-GPU-01 runtime."
 
-## Source truth
-
-- Known source path: `hawkinsoperations-detections/detections/successor/ho-det-001/rule.yml`.
-- Source path status: SOURCE_EXISTS.
-- Source owner repo: hawkinsoperations-detections.
-- What source existence supports: Only that a source artifact exists at a known path under the source owner repo.
-- What source existence does not support: Runtime activity, validation success, signal observation, evidence linkage, public-safe status, or production readiness.
-
-Related HOD-001 encoded-command files may inform review, but those files are not promoted as HO-DET-001 source truth by copy, similarity, or AI interpretation.
-
-## Validation truth
-
-- Known validation path if proven: UNKNOWN.
-- Expected validation path if not proven: hawkinsoperations-validation should own HO-DET-001 validation cases and result outputs after definition.
-- Positive test expectation: A process creation event for PowerShell or pwsh using an encoded command flag should match when the canonical source rule defines that behavior.
-- Negative test expectation: Benign process creation events without encoded command behavior, or allowed administrative patterns if defined by tuning, should not match.
-- Validation output requirement: Preserved pass/fail output with timestamp, validation owner, command or harness reference, result path, and hash or integrity reference if available.
-- What validation supports: Test definition or test result only within the recorded scope.
-- What validation does not support: Runtime deployment, ongoing signal observation, public-safe approval, or broad coverage claims.
-
-Read-only inspection found related HOD-001 validation artifacts in hawkinsoperations-validation, but no HO-DET-001 validation path or result was found.
-
-## Runtime truth
-
-- Required deployment evidence: Deployment, enablement, schedule, or backend configuration evidence from the platform owner, sanitized before public use.
-- Required platform/backend proof: Backend target, rule identifier, deployment state, owner, timestamp, and stale review date.
-- Required timestamp/currentness: Runtime evidence must include collection date/time and must be reviewed for currentness before promotion.
-- Current runtime status: UNKNOWN.
-- Blocked runtime claims: "This detection is active", "This is production-ready", "This proves coverage", and "The repo proves runtime behavior."
-
-## Signal truth
-
-- Required event/log/search/alert evidence: Preserved telemetry, alert, log, or search output showing HO-DET-001 behavior under the governed source and runtime context.
-- Required preserved context: Query or rule reference, event fields needed for review, time window, test or live context label, owner, and redaction/privacy status.
-- Required evidence format: Redacted artifact, evidence ledger entry, or proof record with stable evidence item ID and claim linkage.
-- Current signal status: UNKNOWN.
-- Blocked signal claims: "This catches attacks", "Signal was observed", "The detection validated runtime behavior", and "The successor system has validated detections."
-
-## Evidence truth
-
-| Evidence item ID | Evidence type | Evidence owner | Supports which claim | Does not support which claim | Privacy status | Stale review status | Promotion status |
-|---|---|---|---|---|---|---|---|
-| HO-DET-001-PACKET-001 | Draft proof packet | hawkinsoperations-proof | A governed proof packet exists and defines required boundaries. | Test passed, runtime active, signal observed, evidence-linked, public-safe. | Public-safe candidate wording only; no private terms intentionally included. | Review required before any public use. | DRAFT |
-| HO-DET-001-SOURCE-001 | Source artifact | hawkinsoperations-detections | Source exists at `detections/successor/ho-det-001/rule.yml`. | Runtime activity, validation success, signal observation, public-safe status. | No private terms intentionally included. | Review required before further promotion. | SOURCE_EXISTS |
-| HO-DET-001-VALIDATION-001 | Validation plan/result | hawkinsoperations-validation | UNKNOWN; no HO-DET-001 validation linked. | Runtime activity, signal observation, public-safe status. | UNKNOWN | UNKNOWN | NOT_PROMOTED |
-| HO-DET-001-RUNTIME-001 | Runtime deployment evidence | platform owner | UNKNOWN; no runtime evidence linked. | Signal observation, public-safe status. | UNKNOWN | UNKNOWN | NOT_PROMOTED |
-| HO-DET-001-SIGNAL-001 | Telemetry/search/alert evidence | evidence owner to be assigned | UNKNOWN; no signal evidence linked. | Public-safe status without review and approval. | UNKNOWN | UNKNOWN | NOT_PROMOTED |
-
-## Public proof / public-safe review
-
-- Candidate public wording: "HO-DET-001 demonstrates the HawkinsOperations successor promotion path for a single detection. Current status is limited to source existence and the evidence linked in this proof packet. Runtime-active, signal-observed, evidence-linked, and public-safe claims require separate preserved evidence and review."
-- Sanitization status: No private opportunity terms, hostnames, IP addresses, raw logs, secrets, screenshots, or local machine paths are intentionally included in candidate public wording.
-- Stale review status: NOT_REVIEWED.
-- Claim review status: NOT_REVIEWED.
-- Approval status: NOT_APPROVED.
-
-## Allowed claims
-
-- "A draft proof packet exists for HO-DET-001."
-- "Detection source exists for HO-DET-001."
-- "HO-DET-001 demonstrates the HawkinsOperations successor promotion path for a single detection. Current status is limited to source existence and the evidence linked in this proof packet. Runtime-active, signal-observed, evidence-linked, and public-safe claims require separate preserved evidence and review."
-- "Runtime-active status requires deployment evidence."
-- "Signal-observed status requires preserved telemetry, alert, log, or search output."
-- "Public-safe status requires reviewed wording, privacy review, stale review, evidence linkage, and Raylee approval."
-
-## Blocked claims
+## Blocked Claims
 
 - "This detection is active."
 - "This catches attacks."
 - "This proves coverage."
 - "This is production-ready."
 - "This is public-safe."
-- "The successor system has validated detections."
-- "AI validated this."
-- "The repo proves runtime behavior."
+- "Live Splunk fired."
+- "Cribl routed live telemetry."
+- "Wazuh collected live telemetry."
+- "Production AutoSOC triage occurred."
+- "An analyst approved the disposition."
+- "HO-GPU-01 ran the model."
+- "AI decided the disposition."
 - "The website proves detection status."
 - "Original detections are now successor detections."
-- "HO-DET-001 is evidence-linked."
-- "HO-DET-001 is PUBLIC_SAFE."
 
-## Next promotion gate
+## Next Promotion Gate
 
-The next promotion gate is STATIC_VALIDATED: complete a source review against `hawkinsoperations-detections/detections/successor/ho-det-001/rule.yml` and the rule contract without claiming runtime, signal, evidence-linked, or public-safe status.
+The next promotion gate is runtime deployment evidence or preserved signal evidence, depending on operator priority. Public proof and website updates remain blocked until evidence linkage, privacy review, stale review, wording review, and Raylee approval are complete.


### PR DESCRIPTION
Records merged HO-DET-001 synthetic validation evidence.

Scope:
- Updates proof/records/HO-DET-001.md.
- Adds proof/records/HO-DET-001-SYNTHETIC-VALIDATION-001.json.
- Adds one HO-DET-001 entry to evidence/evidence-ledger.json.
- Updates STATUS.md to reflect merged synthetic validation proof.

Supported claim:
- Supports TEST_VALIDATED_SYNTHETIC_SCOPE only.
- HO-DET-001 passed synthetic validation against controlled positive and negative process-creation fixtures.

Claim boundaries:
- Does not claim runtime-active.
- Does not claim signal-observed.
- Does not claim public-safe.
- Does not claim production-ready.
- Does not claim live Splunk fired.
- Does not claim Cribl-routed telemetry.
- Does not claim Wazuh live collection.
- Does not claim production AutoSOC triage.
- Does not claim HO-GPU-01 runtime-active.
- Does not claim AI-decided disposition.

No website, LinkedIn, platform runtime, .github governance, V1 HawkinsOps, RayleeOps, SignalFoundry, or wazuh-mcp-server update is included.