### PR TITLE
[PROOF] Add AWS-DET-001 fixture proof record

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ This repository stores curated evidence that supports technical claims across de
 - Versioned claims-to-proof mapping
 - Release-level verification snapshots
 
+## Proof Records
+
+- [AWS-DET-001](proof/records/AWS-DET-001.md)
+
 ## Case Studies
 
 - [HO-DET-001: AI Authority Boundary Case Study](docs/case-studies/HO-DET-001-AI-AUTHORITY-BOUNDARY.md)

--- a/proof/records/AWS-DET-001.md
+++ b/proof/records/AWS-DET-001.md
@@ -1,0 +1,83 @@
+# AWS-DET-001 - Denied IAM API Activity From CloudTrail-Style Fixtures
+
+## Header
+
+- Detection ID: AWS-DET-001
+- Detection title: Denied IAM API Activity From CloudTrail-Style Fixtures
+- Proof packet status: TEST_VALIDATED_SYNTHETIC_SCOPE recorded in the proof repo
+- Current proof level: TEST_VALIDATED_SYNTHETIC_SCOPE
+- Current trust class: TEST_VALIDATED_SYNTHETIC_SCOPE
+- Public-safe status: NOT_PUBLIC_SAFE
+- Approval status: NOT_APPROVED
+
+This packet records fixture-only validation evidence for AWS-DET-001. It does not assert AWS-live proof, CloudTrail live proof, cloud runtime-active proof, production deployment, public-safe status, or live cloud signal observation.
+
+## Status Clarification
+
+- Proof packet status: TEST_VALIDATED_SYNTHETIC_SCOPE.
+- Detection proof level: TEST_VALIDATED_SYNTHETIC_SCOPE.
+- Detection trust class: TEST_VALIDATED_SYNTHETIC_SCOPE.
+- Canonical detection source: `hawkinsoperations-detections/detections/cloud/aws/aws-det-001/rule.yml`.
+- Canonical fixture selector: `hawkinsoperations-detections/detections/cloud/aws/aws-det-001/cloudtrail.jsonpath`.
+- Canonical validation path: `hawkinsoperations-validation/reports/aws-det-001/validation-result.json`.
+- AWS-live status: BLOCKED.
+- AWS CloudTrail live status: BLOCKED.
+- Cloud runtime-active status: BLOCKED.
+- Signal-observed status: BLOCKED.
+- Public-safe status: NOT_PUBLIC_SAFE.
+- Approval status: NOT_APPROVED.
+
+## Linked Artifacts
+
+- `hawkinsoperations-detections/detections/cloud/aws/aws-det-001/rule.yml`
+- `hawkinsoperations-detections/detections/cloud/aws/aws-det-001/cloudtrail.jsonpath`
+- `hawkinsoperations-detections/detections/cloud/aws/aws-det-001/README.md`
+- `hawkinsoperations-validation/validation/cloud/aws/aws-det-001/validation-cases.json`
+- `hawkinsoperations-validation/reports/aws-det-001/validation-result.json`
+- `hawkinsoperations-validation/reports/aws-det-001/validation-result.md`
+- `hawkinsoperations-validation/scripts/validate-aws-det-001.py`
+- `hawkinsoperations-validation/scripts/verify-aws-det-001-result-parity.py`
+- `hawkinsoperations-validation/scripts/scan-aws-det-001-claim-boundaries.py`
+- `hawkinsoperations-validation/.github/workflows/aws-det-001-fixture-loop.yml`
+
+## Supported Claim
+
+"AWS-DET-001 passed fixture-only validation against controlled CloudTrail-style IAM denial fixtures."
+
+## Validation Summary
+
+- Validation status: pass
+- Total controlled cases: 6
+- Matched positive count: 3
+- Missed positive cases: none
+- False-positive negative cases: none
+- Validation scope: synthetic CloudTrail-style IAM denied/unauthorized API fixtures only
+- AWS live status: BLOCKED
+- Public-safe status: NOT_PUBLIC_SAFE
+
+## Allowed Claims
+
+- "AWS-DET-001 source exists as a fixture-only CloudTrail-style detection candidate."
+- "AWS-DET-001 passed fixture-only validation against controlled CloudTrail-style IAM denial fixtures."
+- "AWS-DET-001 does not use AWS credentials, live AWS APIs, or live CloudTrail evidence."
+
+## Blocked Claims
+
+- AWS-live proof
+- AWS CloudTrail live proof
+- cloud runtime-active proof
+- production proof
+- public-safe runtime proof
+- signal-observed public proof
+- deployed cloud detection
+- AWS account coverage
+- analyst-approved disposition
+- AI-approved disposition
+
+## Current Claim Ceiling
+
+TEST_VALIDATED_SYNTHETIC_SCOPE
+
+## Next Promotion Gate
+
+AWS-DET-001 requires separate evidence, review, and Raylee approval before any AWS-live, CloudTrail live, cloud runtime-active, signal-observed, evidence-linked, public-safe, production, or deployed-cloud wording is allowed.


### PR DESCRIPTION
## Summary

Adds an AWS-DET-001 fixture proof record and README route.

## Files changed

- README.md
- proof/records/AWS-DET-001.md

## Validation results

AWS-DET-001 local fixture validation passed in the validation repo:

- TOTAL_CASES=6
- MATCHED_POSITIVE_COUNT=3
- MISSED_POSITIVE_CASES=none
- FALSE_POSITIVE_NEGATIVE_CASES=none

Proof repo git diff --check passed with line-ending warnings only.

## Current claim ceiling

AWS-DET-001: TEST_VALIDATED_SYNTHETIC_SCOPE for fixture-only validation.

## Blocked claims preserved

No AWS-live, AWS CloudTrail live, cloud runtime-active, production, public-safe runtime proof, signal-observed public proof, AI-approved disposition, or analyst-approved disposition claim is made.

## Private evidence not included

No private ZIPs, raw evidence, local paths, hostnames, LAN IPs, usernames, VM IDs, MAC addresses, raw model output, private evidence filenames, internal service names, device paths, SSH details, Proxmox details, or GPU host labels are included.

## Next gate

Review after detections and validation fixture-lane PRs are reviewed.