### PR TITLE
proof(ho-det-001): record blocked signal-observed status

### DIFF
--- a/proof/records/HO-DET-001.md
+++ b/proof/records/HO-DET-001.md
@@ -25,6 +25,7 @@ This packet records merged synthetic validation evidence for HO-DET-001 and a ve
 - Synthetic proof record: `proof/records/HO-DET-001-SYNTHETIC-VALIDATION-001.json`.
 - Runtime-active status: BLOCKED.
 - Public signal-observed status: BLOCKED.
+- Signal-observed status: BLOCKED.
 - Private controlled lab runtime match status: VERIFIED by validation PR `HawkinsOperations/hawkinsoperations-validation#22`.
 - Public evidence-linked status: BLOCKED for public runtime or signal evidence; private/internal packet evidence is verifier-backed but not public-safe raw evidence.
 - Public-safe status: NOT_PUBLIC_SAFE.


### PR DESCRIPTION
## Summary

Adds the explicit HO-DET-001 proof-record parity line required by the validation proof-record parity verifier:

- `Signal-observed status: BLOCKED.`

## Boundary

This PR does not promote runtime-active, signal-observed, public-safe, Cribl-routed, Wazuh-routed, Splunk-live, production, fleet-wide, autonomous SOC, AI-approved disposition, or analyst-approved disposition claims.

It changes only `proof/records/HO-DET-001.md` and preserves website rendering as non-proof.

## Validation

- `python scripts\verify_proof_integrity.py`
- HO-DET-001 proof integrity verifier logic against the fix-branch proof record blob
- private-term scan against the fix-branch proof record blob
- blocked-claim context scan against the fix-branch proof record blob
- `git diff --check origin/main fix/ho-det-001-signal-observed-blocked-parity`