### PR TITLE
docs(proof): align HO-DET-001 public label with controlled-test validation

### DIFF
--- a/proof/cards/HO-DET-001.md
+++ b/proof/cards/HO-DET-001.md
@@ -7,18 +7,24 @@
 | ID | HO-DET-001 |
 | Title | Suspicious PowerShell EncodedCommand Execution via Sysmon Event ID 1 |
 | Record type | proof record |
-| Current ceiling | TEST_VALIDATED_SYNTHETIC_SCOPE |
+| Internal verifier token | TEST_VALIDATED_SYNTHETIC_SCOPE |
+| Current ceiling | CONTROLLED_TEST_VALIDATED |
+| Public display label | CONTROLLED_TEST_VALIDATED |
 | Public-safe status | NOT_PUBLIC_SAFE |
 | Last reviewed | UNKNOWN |
 
+Compatibility note: `TEST_VALIDATED_SYNTHETIC_SCOPE` is the internal verifier token preserved for proof-integrity compatibility. `CONTROLLED_TEST_VALIDATED` is the public-facing label used to describe the same controlled-test validation boundary without using legacy public wording.
+
 ## Supported Claim
 
-HO-DET-001 passed synthetic validation against controlled positive and negative process-creation fixtures.
+HO-DET-001 is CONTROLLED_TEST_VALIDATED through a public proof-loop workflow with controlled positive and negative test cases, deterministic pass/fail output, and blocked-claim enforcement.
 
 ## What This Proves
 
 - The proof record exists at `proof/records/HO-DET-001.md`.
-- The synthetic validation result is linked at `hawkinsoperations-validation/reports/ho-det-001/validation-result.json`.
+- The controlled-test validation result is linked at `hawkinsoperations-validation/reports/ho-det-001/validation-result.json`.
+- The public pipeline proof pack is linked at `hawkinsoperations-validation/reports/ho-det-001/pipeline-proof.md`.
+- The machine-readable public pipeline proof pack is linked at `hawkinsoperations-validation/reports/ho-det-001/pipeline-proof.json`.
 - The proof record reports 14 controlled cases: 7 matched positives and 7 negative cases without false-positive negative matches.
 - The proof loop route is linked at `hawkinsoperations-validation/.github/workflows/ho-det-001-proof-loop.yml`.
 - The proof repo verifier exists at `scripts/verify-ho-det-001-proof-integrity.py`.
@@ -44,18 +50,18 @@ HO-DET-001 passed synthetic validation against controlled positive and negative 
 
 ## Control Reality
 
-CI-enforced synthetic scope and verifier-backed proof record. The proof card is route/display only. It does not raise the public ceiling, and it does not turn private/internal controlled lab runtime match evidence into public proof.
+CI-enforced controlled-test scope and verifier-backed proof record. The proof card is route/display only. It does not raise the public ceiling, and it does not turn private/internal controlled lab runtime match evidence into public proof.
 
 ## Current Status
 
 | Plane | Truth |
 |---|---|
 | Repo truth | PROVEN: proof record and linked source artifact routes exist. |
-| Validation truth | PROVEN: synthetic validation passed within controlled fixture scope. |
+| Validation truth | PROVEN: controlled-test validation passed within controlled test-case scope. |
 | Runtime truth | PRIVATE_INTERNAL only where recorded; public runtime-active status remains BLOCKED. |
 | Signal truth | BLOCKED for public signal-observed proof. |
-| Evidence truth | Ledger-backed for synthetic validation and platform guardrail records; private/internal runtime evidence is not public-safe proof. |
-| Public proof | TEST_VALIDATED_SYNTHETIC_SCOPE only; NOT_PUBLIC_SAFE for public promotion. |
+| Evidence truth | Ledger-backed for controlled-test validation and platform guardrail records; private/internal runtime evidence is not public-safe proof. |
+| Public proof | CONTROLLED_TEST_VALIDATED only; NOT_PUBLIC_SAFE for public promotion. |
 
 ## Next Promotion Gate
 
@@ -63,4 +69,4 @@ To raise the claim, HO-DET-001 needs approved evidence linkage for the specific 
 
 ## Reviewer Takeaway
 
-HO-DET-001 has a strong synthetic validation record and verifier-backed proof routing for that scope. Treat this card as a fast map to the proof record, not as proof of live operation, public signal observation, routed telemetry, production coverage, or public-safe status.
+HO-DET-001 has a strong controlled-test validation record and verifier-backed proof routing for that scope. Treat this card as a fast map to the proof record, not as proof of live operation, public signal observation, routed telemetry, production coverage, or public-safe status.

--- a/proof/records/HO-DET-001.md
+++ b/proof/records/HO-DET-001.md
@@ -232,7 +232,7 @@ Related HOD-001 encoded-command artifacts may inform review, but they are not HO
 - Private verifier output SHA256: `A405AE1DF92D639396A8D48C3F6DDE31DFCCBEA3F92E7DE0AFE0CDE87D8F56DC`.
 - Match count: 2 controlled child Windows PowerShell EncodedCommand events tied to marker and search time window.
 - Supported claim: "HO-DET-001 produced a controlled lab runtime match in Splunk."
-- Public ceiling boundary: Current public label and trust class remain CONTROLLED_TEST_VALIDATED until public-safe evidence linkage, privacy review, stale review, wording review, and Raylee approval are complete.
+- Public ceiling boundary: Current internal trust class remains TEST_VALIDATED_SYNTHETIC_SCOPE for verifier compatibility. Public display label, public trust label, and reviewer-facing label remain CONTROLLED_TEST_VALIDATED until public-safe evidence linkage, privacy review, stale review, wording review, and Raylee approval are complete.
 
 ### CONTROLLED_LAB_CRIBL_TO_SPLUNK_MARKER_DELIVERY_VERIFIED
 

--- a/proof/records/HO-DET-001.md
+++ b/proof/records/HO-DET-001.md
@@ -4,25 +4,34 @@
 
 - Detection ID: HO-DET-001
 - Detection title: HO-DET-001 - Suspicious PowerShell EncodedCommand Execution via Sysmon Event ID 1
-- Proof packet status: TEST_VALIDATED_SYNTHETIC_SCOPE recorded in the proof repo
+- Proof packet status: CONTROLLED_TEST_VALIDATED recorded in the proof repo
 - Current proof level: TEST_VALIDATED_SYNTHETIC_SCOPE
 - Current trust class: TEST_VALIDATED_SYNTHETIC_SCOPE
+- Current public label: CONTROLLED_TEST_VALIDATED
+- Public display label: CONTROLLED_TEST_VALIDATED
+- Public trust label: CONTROLLED_TEST_VALIDATED
 - Private controlled runtime status: CONTROLLED_LAB_RUNTIME_MATCH_VERIFIED
 - Public-safe status: NOT_PUBLIC_SAFE
 - Approval status: NOT_APPROVED
 
-This packet records merged synthetic validation evidence for HO-DET-001 and a verifier-backed private controlled lab runtime match. It does not assert runtime activity, production deployment, public-safe status, or live SOC operation.
+Compatibility note: `TEST_VALIDATED_SYNTHETIC_SCOPE` is the internal verifier token preserved for proof-integrity compatibility. `CONTROLLED_TEST_VALIDATED` is the public-facing label used to describe the same controlled-test validation boundary without using legacy public wording.
+
+This packet records merged controlled-test validation evidence for HO-DET-001 and a verifier-backed private controlled lab runtime match. It does not assert runtime activity, production deployment, public-safe status, or live SOC operation.
 
 ## Status Clarification
 
-- Proof packet status: TEST_VALIDATED_SYNTHETIC_SCOPE.
-- Detection proof level: TEST_VALIDATED_SYNTHETIC_SCOPE.
-- Detection trust class: TEST_VALIDATED_SYNTHETIC_SCOPE.
+- Proof packet status: CONTROLLED_TEST_VALIDATED.
+- Internal proof compatibility value - TEST_VALIDATED_SYNTHETIC_SCOPE.
+- Detection public label: CONTROLLED_TEST_VALIDATED.
+- Detection public trust label: CONTROLLED_TEST_VALIDATED.
 - Private controlled runtime status: CONTROLLED_LAB_RUNTIME_MATCH_VERIFIED.
 - Canonical detection source: `hawkinsoperations-detections/detections/successor/ho-det-001/rule.yml`.
 - Canonical Splunk source: `hawkinsoperations-detections/detections/successor/ho-det-001/splunk.spl`.
 - Canonical validation path: `hawkinsoperations-validation/reports/ho-det-001/validation-result.json`.
-- Synthetic proof record: `proof/records/HO-DET-001-SYNTHETIC-VALIDATION-001.json`.
+- Public pipeline proof pack: `hawkinsoperations-validation/reports/ho-det-001/pipeline-proof.md`.
+- Public pipeline proof pack JSON: `hawkinsoperations-validation/reports/ho-det-001/pipeline-proof.json`.
+- Public pipeline proof pack merge: `HawkinsOperations/hawkinsoperations-validation#27` at merge commit `6d4e3ac7b284e380048e8e4f20edf50b6fa9bccb`.
+- Historical validation proof record: `proof/records/HO-DET-001-SYNTHETIC-VALIDATION-001.json`.
 - Runtime-active status: BLOCKED.
 - Public signal-observed status: BLOCKED.
 - Signal-observed status: BLOCKED.
@@ -75,26 +84,26 @@ Related HOD-001 encoded-command artifacts may inform review, but they are not HO
 
 - Public clone-run verifier: `hawkinsoperations-validation/scripts/verify-ho-det-001-reproducible-proof-pack.py`.
 - Public fixture path: `hawkinsoperations-validation/validation/successor/ho-det-001/reproducible-proof/`.
-- Scope: STRUCTURE_AND_BOUNDARY_ONLY / TEST_VALIDATED_SYNTHETIC_SCOPE.
+- Scope: STRUCTURE_AND_BOUNDARY_ONLY / CONTROLLED_TEST_VALIDATED.
 - Validation PR: `HawkinsOperations/hawkinsoperations-validation#18`.
 - This does not prove runtime-active, signal-observed, public-safe runtime proof, live Splunk fired, Cribl-routed telemetry, Wazuh live collection, production-ready, fleet-wide, AWS-live, autonomous SOC, AI-approved disposition, or analyst-approved disposition.
 
 ## Validation Enforcement Status
 
-- Validation enforcement status: CI_ENFORCED_FOR_SYNTHETIC_SCOPE.
+- Validation enforcement status: CI_ENFORCED_FOR_CONTROLLED_TEST_SCOPE.
 - Validation enforcement PR: `HawkinsOperations/hawkinsoperations-validation#10`.
 - Validation enforcement merge commit: `8b48500d2ebbaacd93ac88e77a31dccf1d3b4e25`.
 - Proof-loop workflow: `hawkinsoperations-validation/.github/workflows/ho-det-001-proof-loop.yml`.
-- Enforcement scope: HO-DET-001 synthetic validation, case-packet contract, deterministic triage boundary, claim-boundary scan, result parity, and proof-loop CI.
-- Control boundary: This is a real control only for the exact checked synthetic validation scope. It does not prove runtime-active, signal-observed, evidence-linked public proof, public-safe, production, fleet, Cribl, Wazuh, AWS-live, HO-GPU-01 runtime-active, autonomous SOC, or AI-approved disposition.
+- Enforcement scope: HO-DET-001 controlled-test validation, case-packet contract, deterministic triage boundary, claim-boundary scan, result parity, and proof-loop CI.
+- Control boundary: This is a real control only for the exact checked controlled-test validation scope. It does not prove runtime-active, signal-observed, evidence-linked public proof, public-safe, production, fleet, Cribl, Wazuh, AWS-live, HO-GPU-01 runtime-active, autonomous SOC, or AI-approved disposition.
 
 ## Platform Runtime Contract Enforcement
 
 - Platform runtime contract enforcement status: SATISFIED as a non-promotional guardrail.
 - Platform enforcement PR: `HawkinsOperations/hawkinsoperations-platform#5`.
 - Platform enforcement merge commit: `b3d0ffbd66c1bd5f60f7e9ff99712cdc3e0595bd`.
-- Verifier output: `PLATFORM_RUNTIME_CONTRACT=pass`; `PROOF_CEILING=TEST_VALIDATED_SYNTHETIC_SCOPE`; `PUBLIC_SAFE_STATUS=NOT_PUBLIC_SAFE`; `PROMOTION_STATUS=BLOCKED`; `RUNTIME_ACTIVE=false`; `SIGNAL_OBSERVED=false`; `AI_DECIDED_DISPOSITION=false`.
-- Control boundary: This contract preserves the public ceiling at TEST_VALIDATED_SYNTHETIC_SCOPE. It does not prove runtime-active status, signal-observed public proof, public-safe runtime proof, live Splunk fired, Splunk-proven Runtime Signal 001, Cribl-routed status, Wazuh-routed public proof, production-ready status, fleet-wide coverage, AWS-live status, autonomous SOC operation, AI-approved disposition, or analyst-approved disposition.
+- Verifier output: `PLATFORM_RUNTIME_CONTRACT=pass`; `PROOF_CEILING=CONTROLLED_TEST_VALIDATED`; `PUBLIC_SAFE_STATUS=NOT_PUBLIC_SAFE`; `PROMOTION_STATUS=BLOCKED`; `RUNTIME_ACTIVE=false`; `SIGNAL_OBSERVED=false`; `AI_DECIDED_DISPOSITION=false`.
+- Control boundary: This contract preserves the public ceiling at CONTROLLED_TEST_VALIDATED. It does not prove runtime-active status, signal-observed public proof, public-safe runtime proof, live Splunk fired, Splunk-proven Runtime Signal 001, Cribl-routed status, Wazuh-routed public proof, production-ready status, fleet-wide coverage, AWS-live status, autonomous SOC operation, AI-approved disposition, or analyst-approved disposition.
 
 ## Controlled Runtime Signal Packet 001
 
@@ -119,7 +128,7 @@ Related HOD-001 encoded-command artifacts may inform review, but they are not HO
 
 - Internal status: CONTROLLED_LAB_CRIBL_TO_SPLUNK_MARKER_DELIVERY_VERIFIED.
 - Public-safe status: NOT_PUBLIC_SAFE.
-- Public proof ceiling: TEST_VALIDATED_SYNTHETIC_SCOPE.
+- Public proof ceiling: CONTROLLED_TEST_VALIDATED.
 - Evidence custody: retained outside this repository in the Phase 4H/4I private packet. Local paths and raw capture names are intentionally omitted from this proof record.
 - Marker digest: `sha256:8f061426e75134286ce958b74a7488d70d49960597b6f0c15b265f5fdd47649f`.
 - Supported private/internal claim: "A controlled clean remote marker was delivered through the Cribl-to-Splunk lab lane and observed in expected Splunk rawdata with marker fields preserved."
@@ -127,7 +136,7 @@ Related HOD-001 encoded-command artifacts may inform review, but they are not HO
 
 ## Supported Claim
 
-"HO-DET-001 passed synthetic validation against controlled positive and negative process-creation fixtures."
+"HO-DET-001 is CONTROLLED_TEST_VALIDATED through a public proof-loop workflow with controlled positive and negative test cases, deterministic pass/fail output, and blocked-claim enforcement."
 
 "HO-DET-001 produced a controlled lab runtime match in Splunk."
 
@@ -159,12 +168,13 @@ Related HOD-001 encoded-command artifacts may inform review, but they are not HO
 | HO-DET-001 proof packet exists in the proof repo. | PROVEN | `proof/records/HO-DET-001.md` | "A proof packet exists for HO-DET-001." | "The detection is production proven." | Keep proof current as gates change. |
 | HO-DET-001 detection source exists. | PROVEN | `hawkinsoperations-detections/detections/successor/ho-det-001/rule.yml` | "Detection source exists for HO-DET-001." | "The detection is active." | Runtime deployment evidence. |
 | HO-DET-001 Splunk source exists. | PROVEN | `hawkinsoperations-detections/detections/successor/ho-det-001/splunk.spl` at merge commit `13a74f812fd17027b4a1968b615a4aae78c99f51` | "A Splunk SPL source artifact exists for HO-DET-001." | "Live Splunk fired." | Deploy and preserve runtime/search evidence. |
-| HO-DET-001 synthetic validation passed. | PROVEN | `hawkinsoperations-validation/reports/ho-det-001/validation-result.json` at merge commit `e3bcf6c087b8e22ea62c08438fae6a60e800b094` | "HO-DET-001 passed synthetic validation against controlled positive and negative process-creation fixtures." | "This catches attacks." | Runtime and signal evidence. |
-| HO-DET-001 validation enforcement exists. | PROVEN | `hawkinsoperations-validation#10`; `.github/workflows/ho-det-001-proof-loop.yml`; merge commit `8b48500d2ebbaacd93ac88e77a31dccf1d3b4e25` | "HO-DET-001 validation enforcement exists for synthetic scope." | "Validation enforcement proves runtime, signal, production, or public-safe status." | Runtime/signal/public-safe evidence review. |
+| HO-DET-001 controlled-test validation passed. | PROVEN | `hawkinsoperations-validation/reports/ho-det-001/validation-result.json` at merge commit `e3bcf6c087b8e22ea62c08438fae6a60e800b094` | "HO-DET-001 is CONTROLLED_TEST_VALIDATED through controlled positive and negative process-creation test cases." | "This catches attacks." | Runtime and signal evidence. |
+| HO-DET-001 public pipeline proof pack exists. | PROVEN | `hawkinsoperations-validation/reports/ho-det-001/pipeline-proof.md`; `hawkinsoperations-validation/reports/ho-det-001/pipeline-proof.json`; `HawkinsOperations/hawkinsoperations-validation#27`; merge commit `6d4e3ac7b284e380048e8e4f20edf50b6fa9bccb` | "HO-DET-001 is CONTROLLED_TEST_VALIDATED through a public proof-loop workflow with controlled positive and negative test cases, deterministic pass/fail output, and blocked-claim enforcement." | "This proves runtime-active, production-ready, fleet-wide, or public-safe runtime evidence status." | Runtime/signal/public-safe evidence review. |
+| HO-DET-001 validation enforcement exists. | PROVEN | `hawkinsoperations-validation#10`; `.github/workflows/ho-det-001-proof-loop.yml`; merge commit `8b48500d2ebbaacd93ac88e77a31dccf1d3b4e25` | "HO-DET-001 validation enforcement exists for controlled-test scope." | "Validation enforcement proves runtime, signal, production, or public-safe status." | Runtime/signal/public-safe evidence review. |
 | HO-DET-001 platform runtime contract enforcement exists. | PROVEN | `hawkinsoperations-platform#5`; `contracts/examples/ho-det-001-runtime-contract.sample.json`; merge commit `b3d0ffbd66c1bd5f60f7e9ff99712cdc3e0595bd` | "HO-DET-001 platform runtime contract enforcement exists as a non-promotional guardrail." | "Platform contract enforcement proves runtime-active, signal-observed, public-safe runtime proof, production-ready, fleet-wide, Cribl-routed, Wazuh-routed public proof, AWS-live, autonomous SOC, AI-approved disposition, or analyst-approved disposition." | Runtime/signal/public-safe evidence review. |
 | HO-DET-001 controlled lab runtime match is verifier-backed. | PROVEN_PRIVATE_INTERNAL | `HawkinsOperations/hawkinsoperations-validation#22`; merge commit `b47dd02d08565baec76018f5ef909d1b7895737d`; verifier verdict `VERIFIED_CONTROLLED_LAB_RUNTIME_MATCH_CAPTURED` | "HO-DET-001 produced a controlled lab runtime match in Splunk." | "HO-DET-001 is runtime-active."; "HO-DET-001 has public-safe runtime proof."; "HO-DET-001 is production-ready."; "HO-DET-001 is fleet-wide."; "HO-DET-001 is Cribl-routed."; "HO-DET-001 is Wazuh-routed."; "HO-DET-001 is AWS-live."; "HO-DET-001 runs an autonomous SOC."; "AI approved the disposition."; "An analyst approved the disposition." | Public evidence linkage, privacy review, stale review, wording review, and Raylee approval. |
 | Controlled clean Cribl-to-Splunk lab marker delivery is privately verified. | PROVEN_PRIVATE_INTERNAL | Phase 4H/4I private packet; marker digest `sha256:8f061426e75134286ce958b74a7488d70d49960597b6f0c15b265f5fdd47649f`; status `CONTROLLED_LAB_CRIBL_TO_SPLUNK_MARKER_DELIVERY_VERIFIED` | "A controlled clean remote marker was delivered through the Cribl-to-Splunk lab lane and observed in expected Splunk rawdata with marker fields preserved." | "HO-DET-001 is Cribl-routed."; "Cribl routed live telemetry."; "Live Splunk fired."; "HO-DET-001 is runtime-active."; "HO-DET-001 is production-ready."; "HO-DET-001 is fleet-wide."; "HO-DET-001 is public-safe." | Public evidence linkage, privacy review, stale review, wording review, and Raylee approval. |
-| AutoSOC synthetic triage packet exists. | PROVEN | `hawkinsoperations-validation/validation/successor/ho-det-001/autosoc-triage-packet.json` | "A deterministic synthetic triage packet was generated from the validation result." | "Production AutoSOC triage occurred." | Production AutoSOC run evidence. |
+| AutoSOC triage packet exists. | PROVEN | `hawkinsoperations-validation/validation/successor/ho-det-001/autosoc-triage-packet.json` | "A deterministic controlled-test triage packet was generated from the validation result." | "Production AutoSOC triage occurred." | Production AutoSOC run evidence. |
 | Offline LLM support stub exists. | PROVEN | `hawkinsoperations-validation/validation/successor/ho-det-001/llm-summary.json` | "A deterministic blocked-runtime LLM support stub exists." | "HO-GPU-01 was runtime-active." | Approved local model runtime evidence. |
 | HO-DET-001 runtime-active status is proven. | BLOCKED | No deployment, enablement, schedule, or backend state evidence linked. | "Runtime-active status requires deployment evidence." | "This detection is active." | Preserve runtime deployment evidence. |
 | HO-DET-001 signal-observed status is proven. | BLOCKED | No preserved telemetry, alert, log, or search output linked. | "Signal-observed status requires preserved telemetry, alert, log, or search output." | "This catches attacks." | Preserve signal observation evidence. |
@@ -179,12 +189,13 @@ Related HOD-001 encoded-command artifacts may inform review, but they are not HO
 - Missed positive cases: none
 - False-positive negative cases: none
 - Validation scope: synthetic process-creation fixtures only
+- Validation scope: controlled process-creation test cases only
 - Validation result path: `hawkinsoperations-validation/reports/ho-det-001/validation-result.json`
 
 ## AutoSOC Summary
 
 - Packet ID: HO-DET-001-SYNTHETIC-TRIAGE-001
-- Scope: deterministic synthetic output only
+- Scope: deterministic controlled-test output only
 - Production AutoSOC status: BLOCKED
 - Analyst-approved disposition: BLOCKED
 
@@ -204,14 +215,14 @@ Related HOD-001 encoded-command artifacts may inform review, but they are not HO
 
 ### TEST_DEFINED
 
-- Status: SATISFIED for synthetic scope
+- Status: SATISFIED for controlled-test scope
 - Evidence: `hawkinsoperations-validation/validation/successor/ho-det-001/validation-cases.json`.
 
-### TEST_VALIDATED_SYNTHETIC_SCOPE
+### CONTROLLED_TEST_VALIDATED
 
 - Status: SATISFIED
 - Evidence: `hawkinsoperations-validation/reports/ho-det-001/validation-result.json`.
-- Supported claim: "HO-DET-001 passed synthetic validation against controlled positive and negative process-creation fixtures."
+- Supported claim: "HO-DET-001 is CONTROLLED_TEST_VALIDATED through a public proof-loop workflow with controlled positive and negative test cases, deterministic pass/fail output, and blocked-claim enforcement."
 
 ### CONTROLLED_LAB_RUNTIME_MATCH_VERIFIED
 
@@ -221,7 +232,7 @@ Related HOD-001 encoded-command artifacts may inform review, but they are not HO
 - Private verifier output SHA256: `A405AE1DF92D639396A8D48C3F6DDE31DFCCBEA3F92E7DE0AFE0CDE87D8F56DC`.
 - Match count: 2 controlled child Windows PowerShell EncodedCommand events tied to marker and search time window.
 - Supported claim: "HO-DET-001 produced a controlled lab runtime match in Splunk."
-- Public ceiling boundary: Current proof level and current trust class remain TEST_VALIDATED_SYNTHETIC_SCOPE until public-safe evidence linkage, privacy review, stale review, wording review, and Raylee approval are complete.
+- Public ceiling boundary: Current public label and trust class remain CONTROLLED_TEST_VALIDATED until public-safe evidence linkage, privacy review, stale review, wording review, and Raylee approval are complete.
 
 ### CONTROLLED_LAB_CRIBL_TO_SPLUNK_MARKER_DELIVERY_VERIFIED
 
@@ -248,12 +259,12 @@ Related HOD-001 encoded-command artifacts may inform review, but they are not HO
 ## Allowed Claims
 
 - "HO-DET-001 has merged source artifacts in the detections repository."
-- "HO-DET-001 has merged synthetic validation artifacts in the validation repository."
-- "HO-DET-001 passed synthetic validation against controlled positive and negative process-creation fixtures."
+- "HO-DET-001 has merged controlled-test validation artifacts in the validation repository."
+- "HO-DET-001 is CONTROLLED_TEST_VALIDATED through a public proof-loop workflow with controlled positive and negative test cases, deterministic pass/fail output, and blocked-claim enforcement."
 - "HO-DET-001 produced a controlled lab runtime match in Splunk."
 - "A controlled clean remote marker was delivered through the Cribl-to-Splunk lab lane and observed in expected Splunk rawdata with marker fields preserved."
 - "HO-DET-001 platform runtime contract enforcement exists as a non-promotional guardrail."
-- "A deterministic synthetic AutoSOC triage packet was generated from the HO-DET-001 synthetic validation result."
+- "A deterministic controlled-test AutoSOC triage packet was generated from the HO-DET-001 validation result."
 - "The offline LLM support artifact is a deterministic blocked-runtime stub and does not prove HO-GPU-01 runtime."
 
 ## Blocked Claims


### PR DESCRIPTION
## Summary

- Aligns the HO-DET-001 proof record and proof card with the public display label CONTROLLED_TEST_VALIDATED.
- Preserves TEST_VALIDATED_SYNTHETIC_SCOPE as the internal verifier token required by scripts/verify-ho-det-001-proof-integrity.py.
- Adds compatibility notes that separate the internal proof token from the public display label.
- References the merged validation proof pack from validation PR #27 at merge commit 6d4e3ac7b284e380048e8e4f20edf50b6fa9bccb.

## Proof Boundary

HO-DET-001 is CONTROLLED_TEST_VALIDATED through a public proof-loop workflow with controlled positive and negative test cases, deterministic pass/fail output, and blocked-claim enforcement.

This does not claim runtime-active deployment, production readiness, fleet-wide coverage, live Splunk firing, Cribl-routed telemetry, Wazuh live collection, public-safe runtime evidence, autonomous disposition, or analyst-approved disposition.

## Validation / Checks

- python scripts\verify_proof_integrity.py - passed
- python scripts\verify-ho-det-001-proof-integrity.py - passed
- git diff --check - passed with LF-to-CRLF warnings only

## Blocked Claims

Runtime, production, fleet-wide, public-safe runtime, live Splunk, Cribl-routed telemetry, Wazuh live collection, autonomous disposition, and analyst-approved disposition claims remain blocked.