### PR TITLE
docs(proof): tighten controlled-test wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The left column lists what the current proof record can support. The right colum
 |---|---|
 | HO-DET-001 has merged source artifacts | Not claimed: runtime-active public proof |
 | HO-DET-001 has merged controlled-test validation artifacts | Not claimed: public signal-observed proof |
-| HO-DET-001 passed controlled controlled-test validation | Not claimed: evidence-linked public proof |
+| HO-DET-001 passed controlled-test validation | Not claimed: evidence-linked public proof |
 | Platform contract guardrail exists as a non-promotional guardrail | Not claimed: public-safe runtime proof |
 | Private/internal runtime match status is scoped private/internal | Not claimed: production-ready claim, fleet-wide claim, enterprise deployed claim |
 | AI can support work, but cannot approve claims | Not claimed: live Splunk fired as public proof, Cribl-routed claim, Wazuh-routed claim, AWS-live claim |

--- a/docs/case-studies/PURPLE-TEAM-CLOSED-LOOP-001.md
+++ b/docs/case-studies/PURPLE-TEAM-CLOSED-LOOP-001.md
@@ -12,7 +12,7 @@ AI was allowed to provide support-only triage over a sanitized case packet. AI w
 
 | Step | Status | Evidence basis | Public-safe wording | Blocked wording |
 |---|---|---|---|---|
-| 1. Controlled controlled-test behavior | PROVEN | Controlled-test fixture scope. | Controlled EncodedCommand-style behavior. | Production or live attack. |
+| 1. Controlled-test behavior | PROVEN | Controlled-test fixture scope. | Controlled EncodedCommand-style behavior. | Production or live attack. |
 | 2. Sysmon process-creation style telemetry target | PROVEN | Sysmon Event ID 1/process-creation scope. | Process-creation style telemetry target. | Live telemetry proof. |
 | 3. HO-DET-001 detection source and Splunk source | PROVEN | Proof-record source references. | HO-DET-001 source and Splunk source exist. | Live Splunk fired. |
 | 4. Controlled-test validation with positive and negative fixtures | PROVEN | 14 fixtures: 7 positive, 7 negative. | Controlled-test validation passed. | Runtime or signal proof. |

--- a/proof/records/HO-DET-011.md
+++ b/proof/records/HO-DET-011.md
@@ -82,7 +82,7 @@ This packet records merged source, controlled-test validation, platform case-pac
 - Negative cases not matched: 10.
 - Missed positive cases: none.
 - False-positive negative cases: none.
-- Validation scope: controlled controlled-test Windows service creation fixtures only.
+- Validation scope: controlled-test Windows service creation fixtures only.
 - Supported validation claim: "HO-DET-011 passed controlled-test validation against 17 controlled Windows service creation fixtures."
 - Validation result: CONTROLLED_TEST_VALIDATED for the controlled-test validation layer.
 - Focused validation CI workflow: `hawkinsoperations-validation/.github/workflows/ho-det-011-fixture-loop.yml`.


### PR DESCRIPTION
Summary: Fixes duplicated controlled-test wording in proof README, HO-DET-011 proof record, and the Purple Team closed-loop case study. Validation: proof integrity check passed; git diff --check passed; targeted banned-word/mojibake/duplicated-phrase scan clean for changed files. Governance: claim ceiling unchanged; no proof promotion, runtime evidence, private evidence import, or public-safe status change.