### PR TITLE
proof: define Proof Pack 001 reviewer packet source path

### DIFF
--- a/proof/cards/HO-DET-001.md
+++ b/proof/cards/HO-DET-001.md
@@ -70,3 +70,82 @@ To raise the claim, HO-DET-001 needs approved evidence linkage for the specific 
 ## Reviewer Takeaway
 
 HO-DET-001 has a strong controlled-test validation record and verifier-backed proof routing for that scope. Treat this card as a fast map to the proof record, not as proof of live operation, public signal observation, routed telemetry, production coverage, or public-safe status.
+
+## Planned Signed Release Packet
+
+Current state:
+
+- No signed GitHub Release artifact exists yet for this proof card.
+- The current release effort ceiling is PLANNED_RELEASE_PATH.
+- Repo-side source status: REVIEWER_PACKET_PATH_DEFINED_SOURCE_ONLY.
+- This section defines the future reviewer packet path and exclusion contract only.
+- It does not create `REVIEWER_PACKET.md`, `RELEASE_MANIFEST.json`, `SHA256SUMS.txt`, a zip, a tag, a GitHub Release, a Sigstore bundle, or a signed artifact.
+
+Planned artifact:
+
+- Planned release name: HawkinsOperations Proof Pack 001.
+- Planned tag: `hawkinsoperations-proof-pack-001`.
+- Planned zip: `HAWKINSOPERATIONS_PROOF_PACK_001.zip`.
+- Planned Sigstore bundle: `HAWKINSOPERATIONS_PROOF_PACK_001.sigstore.json`.
+- Planned checksum file: `SHA256SUMS.txt`.
+- Planned generated reviewer packet inside zip: `REVIEWER_PACKET.md`.
+- Planned generated manifest inside zip: `RELEASE_MANIFEST.json`.
+
+Candidate Pack 001 contents:
+
+- `REVIEWER_PACKET.md`
+- `RELEASE_MANIFEST.json`
+- `SHA256SUMS.txt`
+- `SCOPE.md`
+- `GOVERNANCE.md`
+- `STATUS.md`
+- `proof/cards/HO-DET-001.md`
+- `proof/records/HO-DET-001.md`
+- `proof/records/HO-DET-001-CONTROLLED-TEST-VALIDATION-001.json`
+- `evidence/evidence-ledger.json`
+- `evidence/EVIDENCE_LEDGER_SCHEMA.json`
+- `scripts/verify-ho-det-001-proof-integrity.py`
+- `.github/contracts/proof-record.schema.json`
+
+Excluded from Pack 001:
+
+- `README.md`
+- `proof/records/HO-NDR-001.md`
+- `proof/records/HO-DET-011.md`
+- `proof/cards/HO-NDR-001.md`
+- `docs/boundaries/HO-NDR-001-SECURITY-ONION-VISIBILITY-CONTRACT.md`
+- `docs/debugging/*`
+- `proof/records/PROOF-HOD-001-2026-04-21-001.json`
+- `proof/records/AWS-DET-001.md`
+- `proof/cards/AWS-DET-001.md`
+- `.github/workflows/*`
+- `docs/case-studies/*`
+
+Claim boundary:
+
+- The future signed release, once implemented and verified, may support CONTROLLED_TEST_VALIDATED only.
+- It must not promote PUBLIC_SAFE.
+- It must not promote RUNTIME_ACTIVE.
+- It must not promote SIGNAL_OBSERVED.
+- It must not promote EVIDENCE_LINKED public proof.
+- It must not promote production-ready, fleet-wide, live Splunk fired, Cribl-routed, Wazuh-routed, AWS-live, autonomous SOC, AI-approved disposition, AI-decided disposition, analyst-approved disposition, or production AutoSOC claims.
+
+Verification language:
+
+- Future verification wording must remain planned until the release workflow, tag, artifact, Sigstore bundle, and clean reviewer-side verification are actually created and tested.
+- The final Cosign certificate identity must not be frozen until it is confirmed from the actual signed bundle.
+- The expected future OIDC issuer is `https://token.actions.githubusercontent.com`.
+- The expected future release workflow path is `.github/workflows/publish-proof-release.yml`, but that workflow does not exist yet and must not be created in this edit.
+
+Source-side implementation checks:
+
+- The proof integrity verifier must fail if this card no longer names `PLANNED_RELEASE_PATH`.
+- The verifier must fail if Pack 001 no longer names `CONTROLLED_TEST_VALIDATED` as the only allowed future support level.
+- The verifier must fail if Pack 001 no longer keeps `NOT_PUBLIC_SAFE` public-safe status.
+- The verifier must fail if Pack 001 no longer excludes `proof/records/HO-NDR-001.md`.
+- The verifier must fail if Pack 001 wording implies a release, tag, zip, signature, checksum publication, downloaded-artifact verification, or public-safe promotion already exists.
+
+Reviewer meaning:
+
+- A successful future verification would prove artifact integrity and signing provenance for the release artifact.
+- It would not prove runtime activity, signal observation, public-safe status, production coverage, or analyst/AI disposition authority.

--- a/scripts/verify-ho-det-001-proof-integrity.py
+++ b/scripts/verify-ho-det-001-proof-integrity.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 PROOF_RECORD = ROOT / "proof" / "records" / "HO-DET-001.md"
+PROOF_CARD = ROOT / "proof" / "cards" / "HO-DET-001.md"
 
 
 REQUIRED_STATUS_FIELDS = [
@@ -69,6 +70,66 @@ REQUIRED_BLOCKED_CLAIMS = [
     "private model host runtime-active",
     "AI-decided disposition",
     "website proves detection status",
+]
+
+REQUIRED_PROOF_PACK_MARKERS = [
+    "## Planned Signed Release Packet",
+    "No signed GitHub Release artifact exists yet for this proof card.",
+    "The current release effort ceiling is PLANNED_RELEASE_PATH.",
+    "Repo-side source status: REVIEWER_PACKET_PATH_DEFINED_SOURCE_ONLY.",
+    "It does not create `REVIEWER_PACKET.md`, `RELEASE_MANIFEST.json`, `SHA256SUMS.txt`, a zip, a tag, a GitHub Release, a Sigstore bundle, or a signed artifact.",
+    "Planned release name: HawkinsOperations Proof Pack 001.",
+    "Planned tag: `hawkinsoperations-proof-pack-001`.",
+    "Planned zip: `HAWKINSOPERATIONS_PROOF_PACK_001.zip`.",
+    "Planned generated reviewer packet inside zip: `REVIEWER_PACKET.md`.",
+    "Planned generated manifest inside zip: `RELEASE_MANIFEST.json`.",
+    "The future signed release, once implemented and verified, may support CONTROLLED_TEST_VALIDATED only.",
+    "It must not promote PUBLIC_SAFE.",
+    "It must not promote RUNTIME_ACTIVE.",
+    "It must not promote SIGNAL_OBSERVED.",
+    "It must not promote EVIDENCE_LINKED public proof.",
+    "The expected future release workflow path is `.github/workflows/publish-proof-release.yml`, but that workflow does not exist yet and must not be created in this edit.",
+]
+
+REQUIRED_PROOF_PACK_CONTENTS = [
+    "`REVIEWER_PACKET.md`",
+    "`RELEASE_MANIFEST.json`",
+    "`SHA256SUMS.txt`",
+    "`SCOPE.md`",
+    "`GOVERNANCE.md`",
+    "`STATUS.md`",
+    "`proof/cards/HO-DET-001.md`",
+    "`proof/records/HO-DET-001.md`",
+    "`proof/records/HO-DET-001-CONTROLLED-TEST-VALIDATION-001.json`",
+    "`evidence/evidence-ledger.json`",
+    "`evidence/EVIDENCE_LEDGER_SCHEMA.json`",
+    "`scripts/verify-ho-det-001-proof-integrity.py`",
+    "`.github/contracts/proof-record.schema.json`",
+]
+
+REQUIRED_PROOF_PACK_EXCLUSIONS = [
+    "`README.md`",
+    "`proof/records/HO-NDR-001.md`",
+    "`proof/records/HO-DET-011.md`",
+    "`proof/cards/HO-NDR-001.md`",
+    "`docs/boundaries/HO-NDR-001-SECURITY-ONION-VISIBILITY-CONTRACT.md`",
+    "`docs/debugging/*`",
+    "`proof/records/PROOF-HOD-001-2026-04-21-001.json`",
+    "`proof/records/AWS-DET-001.md`",
+    "`proof/cards/AWS-DET-001.md`",
+    "`.github/workflows/*`",
+    "`docs/case-studies/*`",
+]
+
+FORBIDDEN_PROOF_PACK_CURRENT_CLAIMS = [
+    "signed GitHub Release artifact exists",
+    "release artifact exists",
+    "Sigstore bundle exists",
+    "downloaded artifact verification passed",
+    "PUBLIC_SAFE approved",
+    "public-safe approved",
+    "RUNTIME_ACTIVE approved",
+    "SIGNAL_OBSERVED approved",
 ]
 
 PATH_SEPARATOR_CLASS = "[" + chr(92) + "/]"
@@ -217,15 +278,33 @@ def validate_private_leak_boundaries(text: str) -> None:
             fail(f"private/public-safety rejection matched {label}: {match.group(0)}")
 
 
+def validate_proof_pack_planning(card_text: str) -> None:
+    proof_pack_body = section_body(card_text, "Planned Signed Release Packet")
+    for marker in REQUIRED_PROOF_PACK_MARKERS:
+        require_contains(card_text, marker, "proof pack planning marker")
+    for candidate in REQUIRED_PROOF_PACK_CONTENTS:
+        require_contains(proof_pack_body, candidate, "proof pack candidate content")
+    for exclusion in REQUIRED_PROOF_PACK_EXCLUSIONS:
+        require_contains(proof_pack_body, exclusion, "proof pack exclusion")
+    for forbidden in FORBIDDEN_PROOF_PACK_CURRENT_CLAIMS:
+        if forbidden in card_text and f"No {forbidden}" not in card_text:
+            fail(f"proof pack wording implies current publication/promotion: {forbidden}")
+
+
 def main() -> int:
     if not PROOF_RECORD.exists():
         fail("missing proof/records/HO-DET-001.md")
+    if not PROOF_CARD.exists():
+        fail("missing proof/cards/HO-DET-001.md")
     text = PROOF_RECORD.read_text(encoding="utf-8")
+    card_text = PROOF_CARD.read_text(encoding="utf-8")
     validate_status_fields(text)
     validate_sections(text)
     validate_links_and_facts(text)
     validate_blocked_claims(text)
     validate_private_leak_boundaries(text)
+    validate_private_leak_boundaries(card_text)
+    validate_proof_pack_planning(card_text)
     print("HO-DET-001 proof integrity check passed.")
     return 0
 


### PR DESCRIPTION
## Summary
- defines the Proof Pack 001 reviewer-packet path as source-only planning on the HO-DET-001 proof card
- extends the HO-DET-001 proof integrity verifier to enforce Proof Pack planning markers, required candidate contents, exclusions, and no-promotion wording
- keeps `proof/records/HO-NDR-001.md` excluded from Pack 001

## Scope Boundaries
- No release created
- No tag created
- No zip created
- No signing or Sigstore bundle created
- No checksum publication created
- No public-safe promotion
- Public ceiling remains `CONTROLLED_TEST_VALIDATED`
- Public-safe remains `NOT_PUBLIC_SAFE`

## Verification
- `python scripts/verify-ho-det-001-proof-integrity.py` passed with `PYTHONDONTWRITEBYTECODE=1`
- `git diff --check origin/main..proof/pack-001-reviewer-packet-source` passed
- Clean branch diff contains only:
  - `proof/cards/HO-DET-001.md`
  - `scripts/verify-ho-det-001-proof-integrity.py`

## Explicitly Excluded
- `proof/records/HO-NDR-001.md` is not included, not staged, and not touched by this PR.