### PR TITLE
proof: prepare Proof Pack 001 release packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dist/proof-pack-001/

--- a/docs/releases/PROOF_PACK_001_RELEASE_RUNBOOK.md
+++ b/docs/releases/PROOF_PACK_001_RELEASE_RUNBOOK.md
@@ -54,7 +54,20 @@ The local build command is:
 python -B scripts/build-proof-pack-001-zip.py
 ```
 
-The script writes only under `dist/proof-pack-001/` and refuses to write unless that output path is ignored by Git.
+The script writes only under `dist/proof-pack-001/`, which is ignored by Git. Generated ZIPs, checksum sidecars, release artifacts, signatures, signing bundles, and payload manifests must stay untracked and must not be committed.
+
+Official mode requires the literal release approval token. GitHub Actions context is never approval by itself.
+
+```powershell
+python -B scripts/build-proof-pack-001-zip.py --official --release-approved RELEASE_APPROVED_PROOF_PACK_001
+```
+
+Equivalent environment-variable form:
+
+```powershell
+$env:RELEASE_APPROVAL = 'RELEASE_APPROVED_PROOF_PACK_001'
+python -B scripts/build-proof-pack-001-zip.py --official
+```
 
 ## Verify Command
 

--- a/docs/releases/PROOF_PACK_001_RELEASE_RUNBOOK.md
+++ b/docs/releases/PROOF_PACK_001_RELEASE_RUNBOOK.md
@@ -1,0 +1,196 @@
+# Proof Pack 001 Release Runbook
+
+## Boundary
+
+This runbook prepares release packaging only. It does not create a tag, GitHub Release, ZIP upload, signature, signed artifact, website update, public-safe approval, runtime-active claim, signal-observed claim, production claim, autonomous SOC claim, AI-approved disposition claim, or analyst-approved disposition claim.
+
+Official release is not complete until all of these exist and verify cleanly:
+
+- release tag: `hawkinsoperations-proof-pack-001`
+- GitHub Release: `HawkinsOperations Proof Pack 001`
+- release ZIP: `HAWKINSOPERATIONS_PROOF_PACK_001.zip`
+- checksum verification for the release ZIP and payload
+
+Current ceiling remains `CONTROLLED_TEST_VALIDATED`.
+
+Current public-safe status remains `NOT_PUBLIC_SAFE`.
+
+## Pre-Release Checklist
+
+- Confirm the checkout is clean and based on `main`.
+- Confirm `RELEASE_MANIFEST.json` still names `HAWKINSOPERATIONS_PROOF_PACK_001`.
+- Confirm `release_status` remains `CHECK_MODE_SOURCE_ONLY_NO_TAG_NO_RELEASE` until the approved release workflow runs.
+- Confirm no tag named `hawkinsoperations-proof-pack-001` exists.
+- Confirm no GitHub Release for `hawkinsoperations-proof-pack-001` exists.
+- Confirm no generated ZIP, Sigstore bundle, signature, or signed artifact is staged or committed.
+- Confirm human GitHub review exists before merge.
+- Confirm Raylee provides `MERGE_APPROVED` before merge.
+- Confirm Raylee provides `RELEASE_APPROVED_PROOF_PACK_001` before any future release publication step.
+
+## Validation Commands
+
+Run from the repository root:
+
+```powershell
+python -B scripts/verify-ho-det-001-proof-integrity.py
+python -B scripts/verify_proof_integrity.py
+python -B scripts/verify-proof-pack-001-release.py
+python -B scripts/build-proof-pack-001-zip.py --check
+python -B scripts/verify-proof-pack-001-zip.py --check
+git diff --check
+```
+
+## Build Command
+
+The build check is safe and does not write artifacts:
+
+```powershell
+python -B scripts/build-proof-pack-001-zip.py --check
+```
+
+The local build command is:
+
+```powershell
+python -B scripts/build-proof-pack-001-zip.py
+```
+
+The script writes only under `dist/proof-pack-001/` and refuses to write unless that output path is ignored by Git.
+
+## Verify Command
+
+Verifier input is optional only for check mode:
+
+```powershell
+python -B scripts/verify-proof-pack-001-zip.py --check
+```
+
+After a local ZIP build, verify the ZIP:
+
+```powershell
+python -B scripts/verify-proof-pack-001-zip.py dist/proof-pack-001/HAWKINSOPERATIONS_PROOF_PACK_001.zip
+```
+
+## Human Review Gate
+
+Before merge, review the PR in GitHub Files changed and confirm:
+
+- changed files match approved release-packaging scope
+- no generated ZIP, checksum sidecar, signature, bundle, or screenshot is committed
+- scripts are checkable without publication
+- blocked claims remain blocked
+- private leak scan passes
+- official release remains pending
+
+## Merge Gate
+
+Do not merge until Raylee provides:
+
+```text
+MERGE_APPROVED
+```
+
+Green CI/status checks are not merge authority. Codex review is AI labor, not human governance.
+
+## Release Approval Gate
+
+Do not create a tag, GitHub Release, ZIP upload, checksum publication, signature, or signed artifact until Raylee provides:
+
+```text
+RELEASE_APPROVED_PROOF_PACK_001
+```
+
+## Tag Naming
+
+Use this tag only after the release approval gate:
+
+```text
+hawkinsoperations-proof-pack-001
+```
+
+## GitHub Release Title
+
+Use this release title only after the release approval gate:
+
+```text
+HawkinsOperations Proof Pack 001
+```
+
+## GitHub Release Body Draft
+
+```markdown
+# HawkinsOperations Proof Pack 001
+
+This release packages the bounded HO-DET-001 controlled-test proof packet.
+
+Ceiling: CONTROLLED_TEST_VALIDATED
+Public-safe status: NOT_PUBLIC_SAFE
+
+Included payload:
+
+- reviewer packet
+- release manifest
+- source checksum file
+- release notes template
+- scope, governance, and status documents
+- HO-DET-001 proof card and proof record
+- controlled-test validation record
+- evidence ledger and schema
+- proof integrity verifier source
+- proof record schema
+
+This release does not prove runtime-active public proof, signal-observed public proof, evidence-linked public runtime proof, public-safe status, production-ready status, SOCaaS, live Splunk proof, Cribl-routed public proof, Wazuh-routed public proof, AWS-live status, autonomous SOC operation, AI-approved disposition, AI-decided disposition, analyst-approved disposition, fleet-wide deployment, or enterprise deployment.
+
+Website/GitHub rendering is not proof. Evidence and human review authorize claims.
+```
+
+## Rollback Or Cancel Procedure
+
+If any validation fails before release:
+
+- stop the release process
+- do not create or push a tag
+- do not create a GitHub Release
+- do not upload ZIPs or checksums
+- keep generated files unstaged
+- fix the source packet through a normal PR
+- rerun all validation commands
+
+If a tag or GitHub Release is created incorrectly, stop and ask Raylee for an explicit rollback approval before deleting or changing anything.
+
+## Blocked Claims
+
+The release packet must not promote:
+
+- public-safe proof
+- runtime-active proof
+- signal-observed public proof
+- evidence-linked public runtime proof
+- production-ready status
+- SOCaaS-ready status
+- fleet-wide deployment
+- enterprise deployed status
+- live Splunk proof
+- Cribl-routed public proof
+- Wazuh-routed public proof
+- AWS-live status
+- autonomous SOC operation
+- AI-approved disposition
+- AI-decided disposition
+- analyst-approved disposition
+- production AutoSOC status
+
+## Post-Release Website Update Gate
+
+Do not update website or public pointers until:
+
+- the tag exists
+- the GitHub Release exists
+- the release ZIP exists
+- ZIP and payload checksum verification pass
+- Raylee approves the website/public pointer update separately
+
+Website rendering is not proof.
+
+## Optional Signing Future Gate
+
+Signing and Sigstore are future work. Do not add or publish signatures, Sigstore bundles, signed artifacts, or signing workflow behavior without separate explicit approval.

--- a/scripts/build-proof-pack-001-zip.py
+++ b/scripts/build-proof-pack-001-zip.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Build a deterministic local Proof Pack 001 ZIP payload."""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = ROOT / "RELEASE_MANIFEST.json"
+DEFAULT_OUTPUT_DIR = ROOT / "dist" / "proof-pack-001"
+ZIP_NAME = "HAWKINSOPERATIONS_PROOF_PACK_001.zip"
+PAYLOAD_MANIFEST_NAME = "HAWKINSOPERATIONS_PROOF_PACK_001.payload-manifest.json"
+PAYLOAD_SHA256_NAME = "HAWKINSOPERATIONS_PROOF_PACK_001.payload-sha256sums.txt"
+EXPECTED_PACK_ID = "HAWKINSOPERATIONS_PROOF_PACK_001"
+EXPECTED_DETECTION_ID = "HO-DET-001"
+EXPECTED_CEILING = "CONTROLLED_TEST_VALIDATED"
+EXPECTED_PUBLIC_SAFE = "NOT_PUBLIC_SAFE"
+RELEASE_APPROVAL = "RELEASE_APPROVED_PROOF_PACK_001"
+ZIP_TIMESTAMP = (2026, 1, 1, 0, 0, 0)
+
+FORBIDDEN_PAYLOAD_PATTERNS = [
+    "proof/records/HO-NDR-001.md",
+    "docs/debugging/*",
+    "docs/case-studies/*",
+    ".github/workflows/*",
+]
+
+PRIVATE_LEAK_PATTERNS = [
+    ("Windows local path", re.compile(r"(?i)\b(?:C:\\Raylee|C:\\Users|C:\\Work|C:\\Repo|C:\\Data)\b")),
+    ("LAN IP", re.compile(r"\b(?:(?:10|127)\.\d{1,3}|172\.(?:1[6-9]|2[0-9]|3[0-1])|192\.168)\.\d{1,3}\.\d{1,3}\b")),
+    ("raw screenshot name", re.compile(r"(?i)\b(?:screenshot|screen-shot)[-_ ][\w.-]*\.(?:png|jpg|jpeg)\b")),
+    ("raw Security Onion reference", re.compile(r"(?i)\braw\s+Security Onion\b")),
+    ("raw Splunk export reference", re.compile(r"(?i)\braw\s+Splunk\s+export\b")),
+    ("private career screenshot", re.compile(r"(?i)\b(?:LinkedIn|recruiter|opportunity|private contact)[-_ ][\w.-]*\.(?:png|jpg|jpeg)\b")),
+    ("credential-like assignment", re.compile(r"(?i)\b(?:api[_-]?key|password|authorization|cookie|token|secret)\s*[:=]\s*\S+")),
+    ("private GPU host", re.compile(r"\bHO-GPU-\d+\b")),
+]
+
+
+def fail(message: str) -> None:
+    print(f"Proof Pack 001 ZIP build failed: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def load_manifest() -> dict:
+    try:
+        manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail("missing RELEASE_MANIFEST.json")
+    except json.JSONDecodeError as exc:
+        fail(f"invalid RELEASE_MANIFEST.json: {exc}")
+    return manifest
+
+
+def require_manifest_boundary(manifest: dict) -> None:
+    expected = {
+        "pack_id": EXPECTED_PACK_ID,
+        "detection_id": EXPECTED_DETECTION_ID,
+        "ceiling": EXPECTED_CEILING,
+        "public_safe": EXPECTED_PUBLIC_SAFE,
+    }
+    for key, value in expected.items():
+        if manifest.get(key) != value:
+            fail(f"{key} must be {value}")
+    if not isinstance(manifest.get("included_files"), list):
+        fail("included_files must be a list")
+    if not isinstance(manifest.get("excluded_files"), list):
+        fail("excluded_files must be a list")
+
+
+def normalize_name(name: str) -> str:
+    normalized = name.replace("\\", "/").strip("/")
+    if not normalized or normalized.startswith("../") or "/../" in normalized:
+        fail(f"unsafe payload path: {name}")
+    return normalized
+
+
+def matches_any(name: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatchcase(name, pattern) for pattern in patterns)
+
+
+def assert_allowed_payload(manifest: dict) -> list[str]:
+    included = [normalize_name(name) for name in manifest["included_files"]]
+    excluded = [normalize_name(name) for name in manifest["excluded_files"]]
+    if len(included) != len(set(included)):
+        fail("included_files contains duplicates")
+    for name in included:
+        path = ROOT / name
+        if not path.is_file():
+            fail(f"included file missing: {name}")
+        if name in excluded or matches_any(name, excluded):
+            fail(f"included file is excluded: {name}")
+        if matches_any(name, FORBIDDEN_PAYLOAD_PATTERNS):
+            fail(f"forbidden payload path would be included: {name}")
+    if (ROOT / "proof" / "records" / "HO-NDR-001.md").exists():
+        fail("proof/records/HO-NDR-001.md exists and must not be packaged")
+    return included
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    return sha256_bytes(path.read_bytes())
+
+
+def scan_private_leaks(names: list[str]) -> None:
+    for name in names:
+        path = ROOT / name
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for label, pattern in PRIVATE_LEAK_PATTERNS:
+            match = pattern.search(text)
+            if match:
+                fail(f"private/local leakage in {name} matched {label}: {match.group(0)}")
+
+
+def is_ignored(path: Path) -> bool:
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", str(path.relative_to(ROOT).as_posix())],
+        cwd=ROOT,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def output_label(args: argparse.Namespace) -> str:
+    if args.official:
+        approved = args.release_approved == RELEASE_APPROVAL
+        workflow = os.environ.get("GITHUB_ACTIONS") == "true" and os.environ.get("GITHUB_WORKFLOW")
+        if not approved and not workflow:
+            fail("official mode requires release approval input or approved GitHub Actions workflow context")
+        return "OFFICIAL_RELEASE_CANDIDATE_PENDING_GITHUB_RELEASE_PUBLICATION"
+    return "LOCAL_REVIEW_ONLY_NOT_OFFICIAL_RELEASE"
+
+
+def build_payload_manifest(names: list[str], label: str) -> dict:
+    return {
+        "pack_id": EXPECTED_PACK_ID,
+        "detection_id": EXPECTED_DETECTION_ID,
+        "ceiling": EXPECTED_CEILING,
+        "public_safe": EXPECTED_PUBLIC_SAFE,
+        "artifact_status": label,
+        "zip_name": ZIP_NAME,
+        "included_files": [
+            {
+                "path": name,
+                "sha256": sha256_file(ROOT / name),
+                "size": (ROOT / name).stat().st_size,
+            }
+            for name in names
+        ],
+    }
+
+
+def render_payload_sha256sums(payload: dict, zip_path: Path | None = None) -> str:
+    lines = [
+        "# SHA256 checksums for Proof Pack 001 ZIP payload files.",
+        "# This is local packaging checksum data until an approved GitHub Release publishes it.",
+    ]
+    for item in payload["included_files"]:
+        lines.append(f"{item['sha256']}  {item['path']}")
+    if zip_path is not None:
+        lines.append(f"{sha256_file(zip_path)}  {zip_path.name}")
+    return "\n".join(lines) + "\n"
+
+
+def write_zip(names: list[str], zip_path: Path) -> None:
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9) as archive:
+        for name in names:
+            data = (ROOT / name).read_bytes()
+            info = zipfile.ZipInfo(filename=name, date_time=ZIP_TIMESTAMP)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = 0o100644 << 16
+            archive.writestr(info, data)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="validate build inputs without writing artifacts")
+    parser.add_argument("--output-dir", default=str(DEFAULT_OUTPUT_DIR), help="generated ignored output directory")
+    parser.add_argument("--official", action="store_true", help="label output as official release candidate")
+    parser.add_argument("--release-approved", default="", help="required approval token for explicit official mode")
+    args = parser.parse_args()
+
+    manifest = load_manifest()
+    require_manifest_boundary(manifest)
+    names = assert_allowed_payload(manifest)
+    scan_private_leaks(names)
+    label = output_label(args)
+    payload = build_payload_manifest(names, label)
+
+    if args.check:
+        print("Proof Pack 001 ZIP build check passed.")
+        print(f"Payload files: {len(names)}")
+        print(f"Output label: {label}")
+        return 0
+
+    output_dir = Path(args.output_dir)
+    if not output_dir.is_absolute():
+        output_dir = ROOT / output_dir
+    output_dir = output_dir.resolve()
+    try:
+        output_dir.relative_to(ROOT)
+    except ValueError:
+        fail(f"output directory must stay inside repo root: {output_dir}")
+    if not is_ignored(output_dir):
+        fail(f"output directory is not git-ignored: {rel(output_dir)}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    zip_path = output_dir / ZIP_NAME
+    manifest_path = output_dir / PAYLOAD_MANIFEST_NAME
+    sha_path = output_dir / PAYLOAD_SHA256_NAME
+    write_zip(names, zip_path)
+    manifest_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8", newline="\n")
+    sha_path.write_text(render_payload_sha256sums(payload, zip_path), encoding="utf-8", newline="\n")
+    print(f"Built {rel(zip_path)}")
+    print(f"Wrote {rel(manifest_path)}")
+    print(f"Wrote {rel(sha_path)}")
+    print(f"Output label: {label}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build-proof-pack-001-zip.py
+++ b/scripts/build-proof-pack-001-zip.py
@@ -144,10 +144,12 @@ def is_ignored(path: Path) -> bool:
 
 def output_label(args: argparse.Namespace) -> str:
     if args.official:
-        approved = args.release_approved == RELEASE_APPROVAL
-        workflow = os.environ.get("GITHUB_ACTIONS") == "true" and os.environ.get("GITHUB_WORKFLOW")
-        if not approved and not workflow:
-            fail("official mode requires release approval input or approved GitHub Actions workflow context")
+        approval = args.release_approved or os.environ.get("RELEASE_APPROVAL", "")
+        if approval != RELEASE_APPROVAL:
+            fail(
+                "official mode requires --release-approved RELEASE_APPROVED_PROOF_PACK_001 "
+                "or RELEASE_APPROVAL=RELEASE_APPROVED_PROOF_PACK_001"
+            )
         return "OFFICIAL_RELEASE_CANDIDATE_PENDING_GITHUB_RELEASE_PUBLICATION"
     return "LOCAL_REVIEW_ONLY_NOT_OFFICIAL_RELEASE"
 

--- a/scripts/verify-proof-pack-001-zip.py
+++ b/scripts/verify-proof-pack-001-zip.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Verify a local Proof Pack 001 ZIP payload without publishing it."""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = ROOT / "RELEASE_MANIFEST.json"
+EXPECTED_PACK_ID = "HAWKINSOPERATIONS_PROOF_PACK_001"
+EXPECTED_DETECTION_ID = "HO-DET-001"
+EXPECTED_CEILING = "CONTROLLED_TEST_VALIDATED"
+EXPECTED_PUBLIC_SAFE = "NOT_PUBLIC_SAFE"
+ZIP_NAME = "HAWKINSOPERATIONS_PROOF_PACK_001.zip"
+
+FORBIDDEN_PAYLOAD_PATTERNS = [
+    "proof/records/HO-NDR-001.md",
+    "docs/debugging/*",
+    "docs/case-studies/*",
+    ".github/workflows/*",
+]
+
+BLOCKED_TERMS = [
+    "runtime-active",
+    "signal-observed",
+    "evidence-linked public runtime proof",
+    "public-safe",
+    "production-ready",
+    "SOCaaS",
+    "live Splunk",
+    "Cribl-routed",
+    "Wazuh-routed",
+    "AWS-live",
+    "autonomous SOC",
+    "AI-approved disposition",
+    "AI-decided disposition",
+    "analyst-approved disposition",
+    "fleet-wide",
+    "enterprise deployed",
+    "enterprise deployment",
+    "production AutoSOC",
+]
+
+BOUNDARY_MARKERS = [
+    "blocked",
+    "not prove",
+    "does not prove",
+    "does not claim",
+    "not claimed",
+    "not_public_safe",
+    "not public-safe",
+    "must_not_promote",
+    "must not promote",
+    "unsupported",
+    "excluded",
+    "boundary",
+    "no ",
+    "no tag",
+    "no release",
+    "pending",
+    "requires",
+]
+
+PRIVATE_LEAK_PATTERNS = [
+    ("Windows local path", re.compile(r"(?i)\b(?:C:\\Raylee|C:\\Users|C:\\Work|C:\\Repo|C:\\Data)\b")),
+    ("LAN IP", re.compile(r"\b(?:(?:10|127)\.\d{1,3}|172\.(?:1[6-9]|2[0-9]|3[0-1])|192\.168)\.\d{1,3}\.\d{1,3}\b")),
+    ("raw screenshot name", re.compile(r"(?i)\b(?:screenshot|screen-shot)[-_ ][\w.-]*\.(?:png|jpg|jpeg)\b")),
+    ("raw Security Onion reference", re.compile(r"(?i)\braw\s+Security Onion\b")),
+    ("raw Splunk export reference", re.compile(r"(?i)\braw\s+Splunk\s+export\b")),
+    ("private career screenshot", re.compile(r"(?i)\b(?:LinkedIn|recruiter|opportunity|private contact)[-_ ][\w.-]*\.(?:png|jpg|jpeg)\b")),
+    ("credential-like assignment", re.compile(r"(?i)\b(?:api[_-]?key|password|authorization|cookie|token|secret)\s*[:=]\s*\S+")),
+    ("private GPU host", re.compile(r"\bHO-GPU-\d+\b")),
+]
+
+
+def fail(message: str) -> None:
+    print(f"Proof Pack 001 ZIP verification failed: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_manifest() -> dict:
+    try:
+        return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        fail("missing RELEASE_MANIFEST.json")
+    except json.JSONDecodeError as exc:
+        fail(f"invalid RELEASE_MANIFEST.json: {exc}")
+
+
+def normalize_name(name: str) -> str:
+    normalized = name.replace("\\", "/").strip("/")
+    if not normalized or normalized.startswith("../") or "/../" in normalized:
+        fail(f"unsafe payload path: {name}")
+    return normalized
+
+
+def matches_any(name: str, patterns: list[str]) -> bool:
+    return any(fnmatch.fnmatchcase(name, pattern) for pattern in patterns)
+
+
+def expected_payload(manifest: dict) -> list[str]:
+    if manifest.get("pack_id") != EXPECTED_PACK_ID:
+        fail(f"pack_id must be {EXPECTED_PACK_ID}")
+    if manifest.get("detection_id") != EXPECTED_DETECTION_ID:
+        fail(f"detection_id must be {EXPECTED_DETECTION_ID}")
+    if manifest.get("ceiling") != EXPECTED_CEILING:
+        fail(f"ceiling must be {EXPECTED_CEILING}")
+    if manifest.get("public_safe") != EXPECTED_PUBLIC_SAFE:
+        fail(f"public_safe must be {EXPECTED_PUBLIC_SAFE}")
+    included = [normalize_name(name) for name in manifest.get("included_files", [])]
+    excluded = [normalize_name(name) for name in manifest.get("excluded_files", [])]
+    if not included:
+        fail("manifest included_files is empty")
+    for name in included:
+        if name in excluded or matches_any(name, excluded):
+            fail(f"included file is excluded: {name}")
+        if matches_any(name, FORBIDDEN_PAYLOAD_PATTERNS):
+            fail(f"forbidden path would be included: {name}")
+    return included
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def parse_checksums(text: str) -> dict[str, str]:
+    checksums: dict[str, str] = {}
+    for line in text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        match = re.fullmatch(r"([0-9a-f]{64})  (.+)", line)
+        if not match:
+            fail(f"invalid checksum line: {line}")
+        digest, name = match.groups()
+        checksums[normalize_name(name)] = digest
+    return checksums
+
+
+def scan_private_leaks(name: str, data: bytes) -> None:
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        return
+    for label, pattern in PRIVATE_LEAK_PATTERNS:
+        match = pattern.search(text)
+        if match:
+            fail(f"private/local leakage in {name} matched {label}: {match.group(0)}")
+
+
+def validate_claim_boundary(name: str, data: bytes) -> None:
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        return
+    current_section = ""
+    for line in text.splitlines():
+        heading = re.match(r"^#+\s+(.+?)\s*$", line)
+        if heading:
+            current_section = heading.group(1).lower()
+        lower = line.lower()
+        boundary_context = any(marker in current_section for marker in ["blocked", "boundary", "excluded", "not claimed"])
+        for term in BLOCKED_TERMS:
+            if term.lower() not in lower:
+                continue
+            if "not_public_safe" in lower or "not public-safe" in lower:
+                continue
+            if boundary_context or any(marker in lower for marker in BOUNDARY_MARKERS):
+                continue
+            fail(f"blocked claim appears outside boundary context in {name}: {line}")
+
+
+def verify_zip(zip_path: Path, manifest: dict) -> None:
+    if not zip_path.is_file():
+        fail(f"ZIP path does not exist: {zip_path}")
+    expected = expected_payload(manifest)
+    with zipfile.ZipFile(zip_path, "r") as archive:
+        names = [normalize_name(name) for name in archive.namelist()]
+        if names != expected:
+            fail("ZIP included file list does not match RELEASE_MANIFEST.json included_files")
+        for name in names:
+            if matches_any(name, FORBIDDEN_PAYLOAD_PATTERNS):
+                fail(f"forbidden path present in ZIP: {name}")
+        manifest_inside = json.loads(archive.read("RELEASE_MANIFEST.json").decode("utf-8"))
+        if manifest_inside.get("ceiling") != EXPECTED_CEILING:
+            fail(f"ZIP manifest ceiling must be {EXPECTED_CEILING}")
+        if manifest_inside.get("public_safe") != EXPECTED_PUBLIC_SAFE:
+            fail(f"ZIP manifest public_safe must be {EXPECTED_PUBLIC_SAFE}")
+        checksums = parse_checksums(archive.read("SHA256SUMS.txt").decode("utf-8"))
+        expected_checksum_targets = [name for name in expected if name != "SHA256SUMS.txt"]
+        if list(checksums) != expected_checksum_targets:
+            fail("SHA256SUMS.txt target list does not match ZIP payload")
+        for name in names:
+            data = archive.read(name)
+            scan_private_leaks(name, data)
+            validate_claim_boundary(name, data)
+            if name == "SHA256SUMS.txt":
+                continue
+            normalized_digest = sha256_bytes(data.replace(b"\r\n", b"\n"))
+            if checksums.get(name) != normalized_digest:
+                fail(f"checksum mismatch for {name}")
+
+
+def verify_sidecar(zip_path: Path) -> None:
+    sidecar = zip_path.with_name("HAWKINSOPERATIONS_PROOF_PACK_001.payload-sha256sums.txt")
+    if not sidecar.exists():
+        return
+    checksums = parse_checksums(sidecar.read_text(encoding="utf-8"))
+    if checksums.get(zip_path.name) != sha256_bytes(zip_path.read_bytes()):
+        fail("sidecar ZIP checksum does not match")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("zip_path", nargs="?", help="ZIP to verify")
+    parser.add_argument("--check", action="store_true", help="validate verifier inputs without requiring a ZIP")
+    args = parser.parse_args()
+
+    manifest = load_manifest()
+    expected_payload(manifest)
+    if args.check and not args.zip_path:
+        print("Proof Pack 001 ZIP verifier check passed.")
+        print(f"Expected ZIP name: {ZIP_NAME}")
+        return 0
+    if not args.zip_path:
+        fail("ZIP path argument is required unless --check is used")
+    zip_path = Path(args.zip_path)
+    verify_zip(zip_path, manifest)
+    verify_sidecar(zip_path)
+    print("Proof Pack 001 ZIP verification passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Prepares Proof Pack 001 release-packaging scaffolding without publishing a GitHub Release, creating a tag, uploading a ZIP, signing artifacts, changing the proof ceiling, or changing public-safe status.

## What changed

- Added `scripts/build-proof-pack-001-zip.py` for deterministic Proof Pack 001 ZIP payload checks and future local builds.
- Added `scripts/verify-proof-pack-001-zip.py` for ZIP payload, checksum, exclusion, claim-boundary, and private-leak verification.
- Added `docs/releases/PROOF_PACK_001_RELEASE_RUNBOOK.md` with release checklist, validation commands, human review gate, merge gate, future release approval gate, release notes draft, cancel procedure, blocked claims, website update gate, and optional signing future gate.

## What did not happen

- No GitHub Release was created.
- No release tag was created.
- No ZIP was generated, uploaded, staged, or committed.
- No checksum sidecar, signature, signed artifact, Sigstore bundle, screenshot, or release artifact was generated, staged, or committed.
- No website update was made.
- No workflow was converted to publish mode.
- No proof ceiling, public-safe status, runtime-active status, signal-observed status, production status, autonomous SOC status, AI-approved disposition status, or analyst-approved disposition status was promoted.

## Validation results

Passed locally from the repository root:

```powershell
python -B scripts/verify-ho-det-001-proof-integrity.py
python -B scripts/verify_proof_integrity.py
python -B scripts/verify-proof-pack-001-release.py
python -B scripts/build-proof-pack-001-zip.py --check
python -B scripts/verify-proof-pack-001-zip.py --check
git diff --check
```

## Claim boundary

Current ceiling remains `CONTROLLED_TEST_VALIDATED`.

Current public-safe status remains `NOT_PUBLIC_SAFE`.

The new scripts and runbook preserve blocked wording for runtime-active public proof, signal-observed public proof, evidence-linked public runtime proof, public-safe status, production-ready status, SOCaaS, live Splunk proof, Cribl-routed public proof, Wazuh-routed public proof, AWS-live status, autonomous SOC operation, AI-approved disposition, AI-decided disposition, analyst-approved disposition, fleet-wide deployment, enterprise deployment, and production AutoSOC status.

## Release boundary

Official release remains pending until explicit future release approval and actual GitHub Release publication. Official release is not complete until the release tag, GitHub Release, ZIP, and checksum verification exist.

## Private leak scan result

Changed-file scan found no private paths, LAN IPs, host labels, raw evidence filenames, private career material, credentials, secrets, passwords, or API keys. The only scanner-term hits were the verifier pattern definitions and negative no-generated-artifact wording.

## Generated artifact policy

Generated ZIPs and payload checksum sidecars must stay out of git. The build script writes only under `dist/proof-pack-001/` and refuses real writes unless the output path is ignored by Git.

## Human review gate

Visible human GitHub review is required before merge because this PR affects release packaging and claim-bearing proof workflow readiness.

## RELEASE_APPROVED gate for future GitHub Release

A future GitHub Release action must not create a tag, GitHub Release, ZIP upload, checksum publication, signature, or signed artifact until Raylee provides:

```text
RELEASE_APPROVED_PROOF_PACK_001
```