### PR TITLE
docs(proof): add operations accomplishment ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Website and GitHub rendering route reviewers; rendering is not proof. The releas
 
 ## Case Studies
 
+- [Operations Accomplishment Ledger](docs/case-studies/OPERATIONS-ACCOMPLISHMENT-LEDGER.md)
 - [HO-DET-001: AI Authority Boundary Case Study](docs/case-studies/HO-DET-001-AI-AUTHORITY-BOUNDARY.md)
 - [Purple Team Closed Loop 001](docs/case-studies/PURPLE-TEAM-CLOSED-LOOP-001.md)
 

--- a/docs/case-studies/OPERATIONS-ACCOMPLISHMENT-LEDGER.md
+++ b/docs/case-studies/OPERATIONS-ACCOMPLISHMENT-LEDGER.md
@@ -1,0 +1,70 @@
+# HawkinsOperations Operations Accomplishment Ledger
+
+## Purpose
+
+This ledger converts local Operations artifact and logbook evidence into a GitHub-backed accomplishment inventory. It is meant to help reviewers see what was actually built, validated, bounded, or blocked without importing private evidence or raising the public claim ceiling.
+
+This file is a routing and summary artifact. It does not create proof, publish raw evidence, approve public-safe status, or promote runtime, signal, production, autonomous, AI-approved, or analyst-approved claims.
+
+## Proof Boundary
+
+- Default public-facing ceiling: `CONTROLLED_TEST_VALIDATED` or lower.
+- GitHub source files prove source-controlled material exists; they do not prove runtime or signal observation.
+- Validation files prove deterministic checks passed only within the stated fixture or contract scope.
+- Private Operations artifacts and logbook entries were used as local discovery inputs only; raw local paths and private evidence are intentionally omitted here.
+- Website rendering can route reviewers to evidence but is not proof authority.
+- Public use still requires stale review, private-term review, wording review, and Raylee approval.
+
+## Source List
+
+This ledger was derived from:
+
+- Local Operations artifact summaries and candidate maps, reviewed at metadata/summary level.
+- Local Operations logbook completed-work entries, reviewed for accomplishment candidates and collision context.
+- Local repository reconciliation across `.github`, `hawkinsoperations-platform`, `hawkinsoperations-detections`, `hawkinsoperations-validation`, `hawkinsoperations-proof`, and `hawkinsoperations-website`.
+- Existing proof repo files including `README.md`, `STATUS.md`, `REVIEWER_PACKET.md`, `proof/records/README.md`, `proof/indexes/DETECTION_PROOF_STATUS_INDEX.yml`, and proof/case-study records.
+
+## Accomplishment Table
+
+| Date or range | Accomplishment | Repo/source area | Evidence basis | Public-safe claim (bounded wording) | Proof ceiling | GitHub status | Website use recommendation |
+|---|---|---|---|---|---|---|---|
+| 2026-04-29 to 2026-05-21 | Built the first merged HO-DET-001 reviewer receipt loop across source, controlled validation, platform case-packet shape, proof record/card, and bounded website route. | detections, validation, platform, proof, website | `REVIEWER_PACKET.md`; `proof/records/HO-DET-001.md`; validation report and case packet routes named by the reviewer packet. | HawkinsOperations has an end-to-end reviewer route for one controlled-test detection loop. | `CONTROLLED_TEST_VALIDATED` | `GITHUB_PRESENT` | Strong website bullet now; keep "controlled-test" wording and link to proof record/reviewer packet. |
+| 2026-05-21 | Published the Proof Pack 001 release route for a bounded HO-DET-001 reviewer package. | proof | `README.md`; `docs/releases/PROOF_PACK_001_RELEASE_RUNBOOK.md`; release manifest and checksum files. | Proof Pack 001 is a bounded reviewer package for HO-DET-001 controlled-test proof. | `CONTROLLED_TEST_VALIDATED`; release route only | `GITHUB_PRESENT` | Strong proof-route bullet; do not imply official runtime proof or production deployment. |
+| 2026-05-01 to 2026-05-21 | Preserved an AI authority boundary showing support-only triage over sanitized case packets with deterministic checks. | proof, validation | `docs/case-studies/HO-DET-001-AI-AUTHORITY-BOUNDARY.md`; `docs/case-studies/PURPLE-TEAM-CLOSED-LOOP-001.md`; validation verifier links. | AI supported triage preparation but could not approve, promote, close, or decide disposition. | `CONTROLLED_TEST_VALIDATED`; AI support only | `GITHUB_PRESENT` | Strong website/career bullet; emphasize "AI is labor, not authority." |
+| 2026-05-20 to 2026-05-21 | Added a SOAR-style analyst-support case-packet contract route with human-gated response boundaries. | platform, proof | `hawkinsoperations-platform/contracts/examples/soar-case-packet-v0.sample.json`; `REVIEWER_PACKET.md` evidence chain. | A deterministic case-packet shape exists for analyst-support workflows and keeps response authority human-gated. | `CASE_PACKET_CONTRACT_ONLY` | `GITHUB_PRESENT` | Strong bullet after platform PR state is current; do not call it live SOAR deployment. |
+| 2026-05-20 | Consolidated proof-boundary status for detection families through the proof status index. | proof, validation | `proof/indexes/DETECTION_PROOF_STATUS_INDEX.yml`; `validation/VALIDATION_REGISTRY.yml`. | Detection proof status is tracked separately from runtime, signal, public-safe, and website status. | row-specific; many rows `NO_PROOF_RECORD` | `GITHUB_PRESENT` | Strong governance/proof bullet; useful for explaining claim discipline. |
+| 2026-05-20 to 2026-05-21 | Recorded controlled-test validation coverage for identity detections while preserving no-proof-record and no-runtime boundaries. | validation, proof, detections | `validation/VALIDATION_REGISTRY.yml`; `proof/indexes/DETECTION_PROOF_STATUS_INDEX.yml`; identity validation reports. | Identity detections have controlled validation records where listed, but no live IdP, runtime, signal, or public-safe proof is claimed. | `CONTROLLED_TEST_VALIDATED` for validation; `NO_PROOF_RECORD` in proof rows | `GITHUB_PARTIAL`; ID-DET-002 source reconciliation is actively dirty | Website-ready later after active ID-DET-002 work lands and stale source-status drift is resolved. |
+| 2026-05-14 to 2026-05-15 | Recorded HO-DET-011 source, 17-case controlled validation, platform guardrail, and sanitized private evidence summary without public promotion. | detections, validation, platform, proof | `proof/records/HO-DET-011.md`; validation report; platform case-packet verifier routes. | HO-DET-011 has controlled-test validation and a private evidence boundary, while routed telemetry and public-safe proof remain blocked. | private evidence boundary; public use `NOT_PUBLIC_SAFE` | `GITHUB_PRESENT` | Use only as a boundary-discipline bullet; do not use as public runtime proof. |
+| 2026-05-14 to 2026-05-20 | Added HO-DET-012 controlled scheduled-task validation records, while proof record creation remains a separate gate. | validation, proof, detections | `validation/VALIDATION_REGISTRY.yml`; `reports/ho-det-012/validation-result.md`; proof status index. | HO-DET-012 passed controlled validation fixtures, but has no proof record and no runtime or signal proof. | `CONTROLLED_TEST_VALIDATED` in validation; `NO_PROOF_RECORD` in proof | `GITHUB_PARTIAL`; detections-side stale wording remains noted | Needs GitHub proof/status cleanup before website bullet. |
+| 2026-05 | Maintained AWS-DET-001 as fixture-only controlled CloudTrail-style validation, not live AWS proof. | validation, proof, detections | `proof/records/AWS-DET-001.md`; `proof/cards/AWS-DET-001.md`; validation registry. | AWS-DET-001 is fixture-validated in controlled test scope only. | `CONTROLLED_TEST_VALIDATED` | `GITHUB_PRESENT` | Good concise cloud-fixture bullet; explicitly avoid live AWS wording. |
+| 2026-05 | Defined the HO-NDR-001 Security Onion visibility contract and proof-card boundary without importing private evidence. | validation, proof | `docs/boundaries/HO-NDR-001-SECURITY-ONION-VISIBILITY-CONTRACT.md`; `proof/cards/HO-NDR-001.md`; validation registry. | A Security Onion visibility/corroboration contract exists; captured public NDR proof remains blocked. | `VALIDATION_CONTRACT_ENFORCED` / `CROSS_SOURCE_CORROBORATION_CONTRACT_DEFINED` | `GITHUB_PRESENT` | Use as architecture-boundary bullet only; do not claim live Security Onion proof. |
+| 2026-05 | Documented Cribl route-proof discipline by separating private route attribution from broader routing or reduction claims. | proof | `docs/debugging/HO-DET-001-RUNTIME-SIGNAL-003-CRIBL-ROUTE-PUBLIC-REVIEW.md`; local artifact abstracts. | A private validation review separated route attribution from contamination and refused broad Cribl claims. | private reviewer boundary; no public proof promotion | `GITHUB_PARTIAL` | Useful senior-restraint bullet after wording review; avoid "Cribl-routed" as a general claim. |
+| 2026-05-02 | Preserved a case-packet check-mode write defect as a validation-control lesson. | validation | `hawkinsoperations-validation/docs/debugging/CASE_PACKET_CHECK_MODE_WRITE_DEFECT_2026-05-02.md`. | A no-write check path was treated as a control boundary and documented so future checks prove rather than rewrite state. | debugging/control artifact only | `GITHUB_PRESENT` | Strong engineering-quality bullet; no runtime or proof promotion. |
+| 2026-05 | Added local GPU triage support-lane scripts and verifiers with private operational metadata kept out of public proof. | platform, proof case studies | `hawkinsoperations-platform/scripts/run_local_gpu_triage.py`; `hawkinsoperations-platform/scripts/verify_local_gpu_triage.py`; proof case-study AI boundary routes. | A support-only local AI/GPU lane is bounded by deterministic checks and cannot approve disposition or proof. | support-only; private operational status not public proof | `GITHUB_PARTIAL` | Website-ready only as governance/support wording; do not expose private host labels or runtime metadata. |
+| 2026-05 | Built Detection Factory controller/status concepts that track source, validation, proof, and blocked runtime routes separately. | platform, detections, validation, proof | `hawkinsoperations-platform/scripts/ho_factory.py`; detection factory index; validation registry; proof status index. | Detection-factory work tracks what exists, what is validated, and what remains blocked instead of flattening status. | row-specific; source/validation only unless proof record exists | `GITHUB_PARTIAL` | Strong future architecture bullet after collision-free status refresh. |
+| 2026-05 | Hardened organization governance and PR-review authority language around visible human review and claim boundaries. | .github, proof | `.github/governance/*`; `.github/profile/START_HERE.md`; proof README and governance files. | Governance distinguishes AI labor from human review and keeps green CI from becoming merge authority. | governance/source truth only | `GITHUB_PRESENT` | Strong reviewer trust bullet; pair with examples, not as standalone proof of runtime control. |
+
+## Highest-Value Website-Ready Candidates
+
+1. HO-DET-001 controlled-test reviewer receipt loop.
+2. Proof Pack 001 bounded reviewer release route.
+3. AI support-only authority boundary.
+4. SOAR-style case-packet contract.
+5. Proof status index / validation registry separation.
+6. AWS-DET-001 fixture-only cloud validation.
+7. Case-packet check-mode write defect and regression-control story.
+8. HO-NDR-001 visibility contract, only as boundary architecture.
+9. HO-DET-011 controlled validation plus private evidence boundary, only after wording review.
+10. Detection Factory status separation, after active source/status drift is resolved.
+
+## Blocked Or Needs Review
+
+- ID-DET-002, ID-DET-003, ID-DET-004, and HO-DET-012 need stale source/proof/status reconciliation before broad website use.
+- HO-DET-002 is intentionally not evaluated here because active remediation is owned by another agent.
+- Cyber Kill Chain implementation is intentionally not evaluated here.
+- Website Phase 2 work is intentionally not modified here because active Claude work exists in the website repo.
+- Private runtime, screenshot, telemetry, model-host, SIEM, and route evidence remains private unless separately reviewed and approved.
+
+## Final Boundary
+
+This ledger makes the accomplishment surface easier to inspect. It does not approve publication, public-safe status, runtime-active status, signal-observed status, production readiness, autonomous SOC operation, AI-approved disposition, analyst-approved disposition, or any claim stronger than the cited GitHub evidence supports.


### PR DESCRIPTION
## Summary
- Add a bounded Operations accomplishment ledger derived from local Operations artifact/logbook summaries and reconciled against GitHub source truth.
- Link the ledger from the proof README case-study section.

## Proof boundary
- No runtime-active, signal-observed, production, autonomous SOC, AI-approved, analyst-approved, or public-safe runtime claim is promoted.
- Local Operations paths and raw/private evidence are intentionally omitted from the repo-facing prose.
- Website use recommendations are candidate routing guidance only, not publication approval.

## Validation
- git diff --check
- python scripts/verify_detection_proof_status_index.py
- python scripts/verify-ho-det-001-proof-integrity.py
- python scripts/verify-proof-pack-001-release.py
- python scripts/verify_proof_integrity.py
- python scripts/verify-proof-pack-001-zip.py --check
- private marker/path scan on new ledger