### PR TITLE
docs(proof): add HO-DET-012 proof record

### DIFF
--- a/proof/cards/HO-DET-012.md
+++ b/proof/cards/HO-DET-012.md
@@ -1,0 +1,68 @@
+# HO-DET-012 Proof Card
+
+## Header
+
+| Field | Value |
+|---|---|
+| ID | HO-DET-012 |
+| Title | Suspicious Scheduled Task Creation |
+| Record type | proof record |
+| Current ceiling | CONTROLLED_TEST_VALIDATED |
+| Public-safe status | NOT_PUBLIC_SAFE |
+| Last reviewed | UNKNOWN |
+
+## Supported Claim
+
+HO-DET-012 passed controlled-test validation against scheduled-task creation and update fixtures.
+
+## What This Proves
+
+- The proof record exists at `proof/records/HO-DET-012.md`.
+- The detection source route is linked at `hawkinsoperations-detections/detections/successor/ho-det-012/rule.yml`.
+- The validation result route is linked at `hawkinsoperations-validation/reports/ho-det-012/validation-result.json`.
+- The validation case route is linked at `hawkinsoperations-validation/validation/successor/ho-det-012/validation-cases.json`.
+- The validation result reports 8 controlled cases: 4 positive and 4 negative.
+- The validation result reports 0 missed positives and 0 false-positive negatives.
+
+## What This Does NOT Prove
+
+- Runtime-active status is not proven.
+- Signal-observed public proof is blocked.
+- Public-safe runtime proof is blocked.
+- Production-ready, fleet-wide, or deployed status is not proven.
+- Live Splunk proof, live Wazuh proof, live Cribl proof, live Security Onion proof, autonomous SOC operation, AI-approved disposition, and analyst-approved disposition are not proven.
+
+## Evidence / Artifact Route
+
+| Route | Path |
+|---|---|
+| Source record | `proof/records/HO-DET-012.md` |
+| Detection source | `hawkinsoperations-detections/detections/successor/ho-det-012/rule.yml` |
+| Validation | `hawkinsoperations-validation/reports/ho-det-012/validation-result.json` |
+| Validation cases | `hawkinsoperations-validation/validation/successor/ho-det-012/validation-cases.json` |
+| Verifier | `hawkinsoperations-validation/scripts/validate-ho-det-012.py`; `hawkinsoperations-validation/scripts/verify-ho-det-012-result-parity.py`; `hawkinsoperations-validation/scripts/scan-ho-det-012-claim-boundaries.py` |
+| Ledger | UNKNOWN |
+| Related PR/commit | UNKNOWN |
+
+## Control Reality
+
+Controlled validation scope is referenced through validation routes, but this card is route/display only. It does not raise the proof ceiling beyond CONTROLLED_TEST_VALIDATED and does not create runtime, signal, public-safe runtime, production, autonomous SOC, AI-approved, or analyst-approved proof.
+
+## Current Status
+
+| Plane | Truth |
+|---|---|
+| Repo truth | PROVEN: proof record and artifact routes exist. |
+| Validation truth | PROVEN: controlled scheduled-task validation passed within controlled fixture scope. |
+| Runtime truth | BLOCKED for runtime-active status. |
+| Signal truth | BLOCKED for public signal-observed proof. |
+| Evidence truth | Linked validation artifacts exist; evidence ledger entry is UNKNOWN. |
+| Public proof | CONTROLLED_TEST_VALIDATED only; NOT_PUBLIC_SAFE for public promotion. |
+
+## Next Promotion Gate
+
+HO-DET-012 needs separate runtime evidence, signal evidence, public-safe review, stale review, wording review, and Raylee approval before any runtime-active, signal-observed, routed-telemetry, public-safe runtime, production, autonomous SOC, AI-approved, or analyst-approved wording is allowed.
+
+## Reviewer Takeaway
+
+HO-DET-012 is currently a controlled scheduled-task validation proof route. It is useful for reviewing controlled fixture validation, not for claiming live operation, routed telemetry, production deployment, autonomous disposition, or public-safe runtime proof.

--- a/proof/indexes/DETECTION_PROOF_STATUS_INDEX.yml
+++ b/proof/indexes/DETECTION_PROOF_STATUS_INDEX.yml
@@ -93,9 +93,9 @@ entries:
     validation_status: CONTROLLED_TEST_VALIDATED
     platform_visibility_owner: hawkinsoperations-platform
     platform_visibility_status: STATUS_VISIBILITY_PRESENT_NON_PROMOTIONAL
-    proof_record_path: null
-    proof_card_path: null
-    proof_ceiling: NO_PROOF_RECORD
+    proof_record_path: proof/records/HO-DET-012.md
+    proof_card_path: proof/cards/HO-DET-012.md
+    proof_ceiling: CONTROLLED_TEST_VALIDATED
     runtime_status: NOT_PROVEN
     signal_status: NOT_PROVEN
     public_safe_status: NOT_PUBLIC_SAFE
@@ -107,10 +107,14 @@ entries:
       - production-ready
       - live SIEM proof
       - live Splunk proof
+      - live Wazuh proof
+      - live Cribl proof
+      - live Security Onion proof
+      - autonomous SOC
       - AI-approved disposition
       - analyst-approved disposition
-    next_gate: create proof record only under separate proof scope
-    notes: Validation is external truth owned by hawkinsoperations-validation. Proof repo has no HO-DET-012 proof record in this phase.
+    next_gate: blocked until separate runtime or signal evidence review supports any runtime, routed-telemetry, public-safe, production, autonomous SOC, or disposition-authority promotion
+    notes: Existing proof record supports CONTROLLED_TEST_VALIDATED for controlled scheduled-task validation only. It does not promote runtime, signal, public-safe runtime, production, autonomous SOC, AI-approved, or analyst-approved status.
 
   - detection_id: HO-DET-013
     source_truth_owner: hawkinsoperations-detections

--- a/proof/records/HO-DET-012.md
+++ b/proof/records/HO-DET-012.md
@@ -1,0 +1,116 @@
+# HO-DET-012 - Suspicious Scheduled Task Creation
+
+## Header
+
+- Detection ID: HO-DET-012
+- Detection title: Suspicious Scheduled Task Creation
+- Proof packet status: CONTROLLED_TEST_VALIDATED recorded in the proof repo
+- Current proof level: CONTROLLED_TEST_VALIDATED
+- Current trust class: CONTROLLED_TEST_VALIDATED
+- Public-safe status: NOT_PUBLIC_SAFE
+- Approval status: NOT_APPROVED
+
+This packet records source and controlled validation evidence for HO-DET-012. It does not assert runtime-active status, signal-observed status, public-safe runtime proof, production deployment, live SIEM routing, autonomous SOC operation, AI-approved disposition, or analyst-approved disposition.
+
+## Status Clarification
+
+- Proof packet status: CONTROLLED_TEST_VALIDATED.
+- Detection proof level: CONTROLLED_TEST_VALIDATED.
+- Detection trust class: CONTROLLED_TEST_VALIDATED.
+- Canonical detection source: `hawkinsoperations-detections/detections/successor/ho-det-012/rule.yml`.
+- Canonical Splunk source: `hawkinsoperations-detections/detections/successor/ho-det-012/splunk.spl`.
+- Canonical Wazuh source: `hawkinsoperations-detections/detections/successor/ho-det-012/wazuh.xml`.
+- Canonical event mapping: `hawkinsoperations-detections/detections/successor/ho-det-012/event-mapping.yml`.
+- Canonical source status: `hawkinsoperations-detections/detections/successor/ho-det-012/status.yml`.
+- Canonical validation cases: `hawkinsoperations-validation/validation/successor/ho-det-012/validation-cases.json`.
+- Canonical validation result: `hawkinsoperations-validation/reports/ho-det-012/validation-result.json`.
+- Validation runner: `hawkinsoperations-validation/scripts/validate-ho-det-012.py`.
+- Validation result parity verifier: `hawkinsoperations-validation/scripts/verify-ho-det-012-result-parity.py`.
+- Validation claim-boundary scanner: `hawkinsoperations-validation/scripts/scan-ho-det-012-claim-boundaries.py`.
+- Runtime-active proof: NOT_PROVEN / blocked.
+- Signal-observed proof: NOT_PROVEN / blocked.
+- Public-safe runtime proof: NOT_PUBLIC_SAFE / blocked.
+- Public-safe status: NOT_PUBLIC_SAFE.
+- Approval status: NOT_APPROVED.
+
+## Linked Artifacts
+
+- `hawkinsoperations-detections/detections/successor/ho-det-012/rule.yml`
+- `hawkinsoperations-detections/detections/successor/ho-det-012/splunk.spl`
+- `hawkinsoperations-detections/detections/successor/ho-det-012/wazuh.xml`
+- `hawkinsoperations-detections/detections/successor/ho-det-012/event-mapping.yml`
+- `hawkinsoperations-detections/detections/successor/ho-det-012/status.yml`
+- `hawkinsoperations-detections/detections/successor/ho-det-012/README.md`
+- `hawkinsoperations-validation/validation/successor/ho-det-012/validation-cases.json`
+- `hawkinsoperations-validation/reports/ho-det-012/validation-result.json`
+- `hawkinsoperations-validation/reports/ho-det-012/validation-result.md`
+- `hawkinsoperations-validation/scripts/validate-ho-det-012.py`
+- `hawkinsoperations-validation/scripts/verify-ho-det-012-result-parity.py`
+- `hawkinsoperations-validation/scripts/scan-ho-det-012-claim-boundaries.py`
+
+## Supported Claim
+
+"HO-DET-012 passed controlled-test validation against scheduled-task creation and update fixtures."
+
+## Validation Summary
+
+- Validation status: pass.
+- Validation scope: controlled scheduled-task validation only.
+- Validation evidence source: `hawkinsoperations-validation/reports/ho-det-012/validation-result.json`.
+- Total controlled cases: 8.
+- Positive cases: 4.
+- Negative cases: 4.
+- Matched positive count: 4.
+- Missed positive cases: 0.
+- False-positive negative cases: 0.
+- Validation result: CONTROLLED_TEST_VALIDATED for the controlled validation layer.
+- Proof ceiling: CONTROLLED_TEST_VALIDATED.
+- Runtime-active proof: NOT_PROVEN / blocked.
+- Signal-observed proof: NOT_PROVEN / blocked.
+- Public-safe runtime proof: NOT_PUBLIC_SAFE / blocked.
+
+## Source Summary
+
+- HO-DET-012 source artifacts exist in `hawkinsoperations-detections`.
+- Source surfaces include Sigma-style YAML, Splunk SPL, Wazuh XML, event mapping, README, and status metadata.
+- The source package documents scheduled-task telemetry assumptions and false-positive review guidance.
+- The source package does not prove live deployment, live SIEM routing, public-safe runtime proof, or production readiness.
+
+## Allowed Claims
+
+- "HO-DET-012 source artifacts exist in the detections repository."
+- "HO-DET-012 passed controlled-test validation against scheduled-task creation and update fixtures."
+- "HO-DET-012 validation covered 8 controlled cases: 4 positive and 4 negative."
+- "HO-DET-012 validation recorded 0 missed positives and 0 false-positive negatives."
+- "HO-DET-012 is capped at CONTROLLED_TEST_VALIDATED and NOT_PUBLIC_SAFE."
+
+## Blocked Claims
+
+- runtime-active
+- signal-observed
+- public-safe runtime proof
+- evidence-linked public proof
+- live Splunk proof
+- live Wazuh proof
+- live Cribl proof
+- live Security Onion proof
+- production-ready
+- production deployment
+- fleet-wide
+- autonomous SOC
+- AI-approved disposition
+- analyst-approved disposition
+- attack coverage completeness
+- scheduled-task coverage completeness
+
+## Current Claim Ceiling
+
+CONTROLLED_TEST_VALIDATED
+
+## Boundary Statement
+
+No live Splunk, Wazuh, Cribl, Security Onion, or production route proof is claimed. HO-DET-012 requires separate runtime evidence, signal evidence, public-safe review, stale review, wording review, and Raylee approval before any claim beyond CONTROLLED_TEST_VALIDATED is allowed.
+
+## Next Promotion Gate
+
+HO-DET-012 requires separate runtime or signal evidence review before any runtime-active, signal-observed, routed-telemetry, public-safe runtime, production, autonomous SOC, AI-approved, or analyst-approved wording can advance.


### PR DESCRIPTION
- Adds governed HO-DET-012 proof record for controlled validation.
- Eliminates NO_PROOF_RECORD for HO-DET-012 only.
- Does not claim runtime-active, signal-observed, public-safe runtime, production-ready, autonomous SOC, AI-approved, or analyst-approved status.
- Website untouched.