### PR TITLE
docs(proof): add HO-DET-012 runtime review packet

### DIFF
--- a/docs/runtime/HO-DET-012-RUNTIME-CORROBORATION-REVIEW.md
+++ b/docs/runtime/HO-DET-012-RUNTIME-CORROBORATION-REVIEW.md
@@ -1,0 +1,124 @@
+# HO-DET-012 Runtime Corroboration Review
+
+## Purpose
+
+This review packet evaluates whether the private HO-DET-012 runtime receipt can support public-facing wording without exposing raw private evidence or promoting unsupported runtime, signal, production, or disposition claims.
+
+## Review Decision
+
+- Review packet status: READY_FOR_HUMAN_PUBLIC_SAFE_REVIEW.
+- Public-safe candidate status: REVIEW_REQUIRED.
+- Proof/index promotion: NOT_APPROVED.
+- Website update: BLOCKED_PENDING_PUBLIC_SAFE_CANDIDATE_OR_STRONGER.
+- Splunk status: NOT_VERIFIED.
+- Raw private evidence public: false.
+- AI decided disposition: false.
+- Human review required: true.
+
+HO-DET-012 should not move to `PUBLIC_SAFE_CANDIDATE` from this packet alone. The packet defines bounded candidate wording for review, but the current receipt remains private evidence and the proof index must stay at `PRIVATE_RUNTIME_EVIDENCE_CAPTURED` / `NOT_PUBLIC_SAFE`.
+
+## What Evidence Exists
+
+The private evidence set contains:
+
+- a controlled private lab runtime receipt for one approved Windows scheduled-task creation test;
+- local Windows telemetry categories consistent with scheduled-task creation and task scheduler registration context;
+- private Wazuh observation for the same controlled test;
+- cleanup confirmation showing the disposable scheduled task was removed;
+- a private evidence hash manifest;
+- a committed redacted sample and deterministic runtime receipt verifier in the validation repository.
+
+The evidence is retained outside public repositories. This packet does not include raw telemetry, raw Wazuh lines, local event payloads, command output, private storage paths, host identifiers, user identifiers, internal network details, the exact task marker, or the exact correlation marker.
+
+## What Can Be Public
+
+The following can be public as bounded review wording:
+
+> HO-DET-012 produced a private lab runtime receipt from a controlled Windows scheduled-task creation test. The run produced local Windows telemetry and private Wazuh observation, with raw evidence retained outside public repos. Public-safe runtime publication remains under review.
+
+The following supporting statements are also safe when kept together with the same boundary:
+
+- The receipt is private runtime evidence, not public runtime proof.
+- The validation repository contains a deterministic verifier, schema, and redacted sample for the private receipt shape.
+- Splunk remains `NOT_VERIFIED`.
+- Raw private evidence is not included in public repositories.
+- Human review is required before any public-safe runtime or signal wording can advance.
+
+## What Must Stay Private
+
+The following must not be published in repo prose, website copy, reviewer-facing public packets, or public comments:
+
+- raw Wazuh lines;
+- raw Windows event payloads;
+- exact command output;
+- host identifiers;
+- user identifiers;
+- private storage paths;
+- internal IP addresses or URLs;
+- sensitive authentication material or private configuration values;
+- the exact scheduled-task marker or task name;
+- the exact correlation marker;
+- raw telemetry counts used as proof claims;
+- private evidence hashes as public proof anchors without separate review.
+
+Hashes may support local integrity review, but this packet does not list them publicly because they still point back to private evidence structure.
+
+## Exact Public Wording
+
+Use this exact candidate wording only with the review boundary intact:
+
+> HO-DET-012 produced a private lab runtime receipt from a controlled Windows scheduled-task creation test. The run produced local Windows telemetry and private Wazuh observation, with raw evidence retained outside public repos. Public-safe runtime publication remains under review.
+
+Do not claim public runtime proof closed.
+Do not claim public signal-observed proof.
+Do not claim Splunk observed.
+Do not claim production-ready status.
+Do not claim fleet-wide status.
+Do not claim autonomous SOC operation.
+Do not claim AI-approved disposition.
+Do not claim analyst-approved disposition.
+
+## Public-Safe Candidate Decision
+
+Current decision: REVIEW_REQUIRED.
+
+Reason:
+
+- the private receipt explicitly keeps public-safe status under review;
+- raw evidence remains private;
+- public evidence linkage has not been approved;
+- redaction review has not approved exact public evidence anchors;
+- stale review and wording review remain pending;
+- human approval for public-safe runtime or signal publication has not been recorded.
+
+The strongest current proof state remains private runtime evidence captured with public-safe publication blocked.
+
+## Website Decision
+
+Website update is not allowed from this packet alone.
+
+Website status:
+
+`WEBSITE_PUBLIC_RUNTIME_SUMMARY_BLOCKED_PENDING_REVIEW`
+
+A website update may be reconsidered only after HO-DET-012 reaches `PUBLIC_SAFE_CANDIDATE` or stronger through a separate public-safe review and approval gate.
+
+## Claim Boundary
+
+This packet supports only:
+
+- private lab runtime receipt captured;
+- raw evidence retained privately;
+- deterministic receipt-verifier support exists;
+- public-safe runtime publication remains under review.
+
+This packet does not prove runtime-active public proof.
+This packet does not prove signal-observed public proof.
+This packet does not prove Splunk observation.
+This packet does not prove production deployment.
+This packet does not prove fleet-wide coverage.
+This packet does not prove scheduled-task coverage completeness.
+This packet does not prove autonomous SOC operation.
+This packet does not prove AI-approved disposition.
+This packet does not prove AI-decided disposition.
+This packet does not prove analyst-approved disposition.


### PR DESCRIPTION
Adds a sanitized runtime corroboration review packet for the HO-DET-012 private runtime receipt.

This documents:
- what private runtime evidence exists
- what may be summarized publicly
- what must remain private
- why public-safe promotion remains blocked
- why website publication remains blocked

Boundary:
- Keeps REVIEW_REQUIRED / NOT_PUBLIC_SAFE.
- Does not promote PUBLIC_SAFE_CANDIDATE.
- Does not promote public runtime proof.
- Does not promote public signal-observed proof.
- Does not claim Splunk observation.
- Does not claim production readiness, fleet-wide proof, autonomous SOC, AI-approved disposition, or analyst-approved disposition.
- Does not include raw private evidence.

Validation:
- verify_detection_proof_status_index.py
- verify_proof_integrity.py
- git diff --check
- targeted private identifier / overclaim scan