### PR TITLE
Pin Phase 9 platform manifest checkout

### DIFF
--- a/.github/workflows/governance-gate.yml
+++ b/.github/workflows/governance-gate.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: HawkinsOperations/hawkinsoperations-platform
+          ref: e0580fc8d0b141cbdd71c1b95e3d7885a1d708e0
           path: hawkinsoperations-platform
       - name: Verify Lifetime Case Ledger proof summary
         run: |

--- a/proof/records/lifetime-case-ledger-v1-public-summary.json
+++ b/proof/records/lifetime-case-ledger-v1-public-summary.json
@@ -73,7 +73,7 @@
     "evidence-linked public proof",
     "live Splunk firing",
     "production triage",
-    "LOCAL_GPU_SUPPORT_NODE runtime-active",
+    "local GPU support node runtime-active",
     "Cribl-routed proof",
     "Wazuh-routed proof",
     "AWS-live",

--- a/scripts/verify-lifetime-ledger-public-summary.py
+++ b/scripts/verify-lifetime-ledger-public-summary.py
@@ -76,7 +76,7 @@ BLOCKED_CLAIMS = {
     "evidence-linked public proof",
     "live Splunk firing",
     "production triage",
-    "LOCAL_GPU_SUPPORT_NODE runtime-active",
+    "local GPU support node runtime-active",
     "Cribl-routed proof",
     "Wazuh-routed proof",
     "AWS-live",


### PR DESCRIPTION
## Summary
- Pins the Phase 9 governance-gate platform checkout to the approved Phase 8 manifest commit `e0580fc8d0b141cbdd71c1b95e3d7885a1d708e0`.
- Generalizes one blocked-claim label from an internal-looking node token to `local GPU support node runtime-active` while preserving the blocked runtime-active boundary.
- Keeps the proof summary bounded to the Phase 8 manifest, ledger counts, and blocked-claim state.

## Boundary
- Ledger public-safe status remains `NOT_PUBLIC_SAFE`.
- Proof ceiling remains `SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY`.
- No ledger append, SQLite mutation, raw evidence import, runtime-active public status, signal-observed public status, public proof promotion, SOCaaS, production deployment, autonomous SOC, disposition authority, or case closure is claimed.

## Validation
- `python scripts/verify-lifetime-ledger-public-summary.py --platform-manifest ../hawkinsoperations-platform/contracts/lifetime-case-ledger-v1-state-manifest.json --format json`
- `python scripts/verify_proof_integrity.py`
- `python scripts/verify_detection_proof_status_index.py`
- `python scripts/verify-ho-det-001-proof-integrity.py`
- `python scripts/verify-proof-pack-001-release.py`
- `python scripts/build-proof-pack-001-zip.py --check`
- `python scripts/verify_cyber_kill_chain_coverage.py`
- `python -m py_compile scripts/verify-lifetime-ledger-public-summary.py scripts/verify_proof_integrity.py scripts/verify_detection_proof_status_index.py`
- `git diff --check`
- placeholder/private-leakage/structured-boundary scans on the changed diff

Addresses the unresolved Codex review thread on PR #66 about pinning the platform checkout.