### PR TITLE
docs: add reviewer proof trust map

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,20 @@ Badges report GitHub Actions workflow check status only. They do not prove runti
 | Ledger summary verifier | `lifetime-ledger-public-summary` | `proof/records/lifetime-case-ledger-v1-public-summary.json` matches the pinned platform manifest counts, proof ceiling, six-repo anchors, and blocked-claim boundaries. | Ledger status remains `NOT_PUBLIC_SAFE`; proof ceiling remains `SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY`. |
 | Ledger proof bundle verifier | `lifetime-ledger-proof-bundle` | `proof/records/lifetime-case-ledger-v1-proof-bundle.json` packages the summary, pinned platform manifest reference, six-repo anchors, verifier commands, and reviewer steps without importing private evidence. | Ledger status remains `NOT_PUBLIC_SAFE`; proof ceiling remains `SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY`. |
 
+## Reviewer Proof Map
+
+Use [proof/indexes/reviewer-proof-map.md](proof/indexes/reviewer-proof-map.md) as the proof-owned reviewer map for the Lifetime Case Ledger chain.
+
+The map ties together the ledger public summary, proof bundle, badge/status checks, evidence preservation map, branch cleanup map, blocked claims, and proof authority boundaries. It keeps the ledger at 4 events / 4 cases, `NOT_PUBLIC_SAFE`, and `SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY`.
+
+The companion machine-readable map lives at [proof/indexes/reviewer-proof-map.json](proof/indexes/reviewer-proof-map.json) and is checked by:
+
+```powershell
+python scripts/verify-reviewer-proof-map.py --platform-root ../hawkinsoperations-platform --github-root ../.github
+```
+
+The reviewer proof map does not prove runtime-active public proof, signal-observed public proof, public-safe runtime proof, production deployment, SOCaaS deployment, autonomous SOC, AI-approved disposition, analyst-approved disposition, case closure, Cribl-routed telemetry, Wazuh-routed telemetry, AWS-live evidence, fleet-wide coverage, live Splunk firing, website as proof authority, badge as proof authority, or Project #1 as proof authority.
+
 ## What This Repository Proves
 
 | Proof surface | What it can support |

--- a/proof/indexes/reviewer-proof-map.json
+++ b/proof/indexes/reviewer-proof-map.json
@@ -1,0 +1,287 @@
+{
+  "map_id": "REVIEWER_PROOF_MAP_V1",
+  "map_version": "proof_trust_backup_reviewer_map_v1",
+  "artifact_class": "proof_owned_reviewer_map",
+  "owner_repo": "hawkinsoperations-proof",
+  "classification_only": true,
+  "ledger_status": "NOT_PUBLIC_SAFE",
+  "proof_ceiling": "SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY",
+  "corrected_platform_manifest_path": "../hawkinsoperations-platform/contracts/lifetime-case-ledger-v1-state-manifest.json",
+  "ledger_summary": {
+    "summary_artifact": "proof/records/lifetime-case-ledger-v1-public-summary.json",
+    "bundle_artifact": "proof/records/lifetime-case-ledger-v1-proof-bundle.json",
+    "total_ledger_events": 4,
+    "total_cases": 4,
+    "ledger_public_safe_status": "NOT_PUBLIC_SAFE",
+    "case_closure_authority": false,
+    "summary_boundary": "Bounded ledger counts and reviewer navigation only."
+  },
+  "authority_boundaries": {
+    "proof_repo_is_reviewer_map_owner": true,
+    "platform_owns_ledger_factory_and_verifier_mechanics": true,
+    "github_owns_reviewer_routing_governance": true,
+    "website_render_surfaces_are_proof_authority": false,
+    "badges_are_proof_authority": false,
+    "project_one_is_proof_authority": false,
+    "github_project_mutation_performed": false,
+    "proof_promotion_performed": false
+  },
+  "required_proof_artifacts": [
+    "proof/records/lifetime-case-ledger-v1-public-summary.json",
+    "proof/records/lifetime-case-ledger-v1-proof-bundle.json",
+    "proof/indexes/lifetime-case-ledger-v1-evidence-map.json",
+    "proof/indexes/hawkinsoperations-branch-cleanup-map.json",
+    "scripts/verify-lifetime-ledger-public-summary.py",
+    "scripts/verify-lifetime-ledger-proof-bundle.py",
+    "scripts/verify-lifetime-ledger-badges.py",
+    "scripts/verify-lifetime-ledger-evidence-map.py",
+    "scripts/verify-hawkinsoperations-branch-cleanup-map.py",
+    "scripts/verify-reviewer-proof-map.py"
+  ],
+  "read_only_platform_artifacts": [
+    "contracts/lifetime-case-ledger-v1-state-manifest.json"
+  ],
+  "read_only_github_artifacts": [
+    "profile/README.md"
+  ],
+  "proof_chain": {
+    "visual": "platform ledger -> platform state manifest -> proof public summary -> proof bundle -> badge/status checks -> render-only downstream surfaces",
+    "stages": [
+      {
+        "id": "platform_ledger",
+        "owner": "hawkinsoperations-platform",
+        "artifact_path": "evidence/autosoc-case-ledger-v0.sqlite",
+        "what_it_proves": "A platform ledger seed bridge exists for the 4 events / 4 cases count spine.",
+        "what_it_does_not_prove": "Runtime, signal, public proof, deployment, disposition, and closure claims remain blocked.",
+        "current_status": "tracked platform seed bridge; ledger remains NOT_PUBLIC_SAFE",
+        "proof_ceiling": "SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY"
+      },
+      {
+        "id": "platform_state_manifest",
+        "owner": "hawkinsoperations-platform",
+        "artifact_path": "contracts/lifetime-case-ledger-v1-state-manifest.json",
+        "what_it_proves": "A pinned source manifest records the ledger count state, repo anchors, and proof boundary inputs.",
+        "what_it_does_not_prove": "A manifest is source truth only and does not establish runtime, signal, public-safe, or closure authority.",
+        "current_status": "pinned read-only verifier input",
+        "proof_ceiling": "SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY"
+      },
+      {
+        "id": "proof_public_summary",
+        "owner": "hawkinsoperations-proof",
+        "artifact_path": "proof/records/lifetime-case-ledger-v1-public-summary.json",
+        "what_it_proves": "The proof repo owns a bounded public summary for 4 events / 4 cases, zero public-safe cases, and zero closed cases.",
+        "what_it_does_not_prove": "The summary is not runtime evidence and does not approve public proof or case disposition.",
+        "current_status": "source-controlled summary; NOT_PUBLIC_SAFE",
+        "proof_ceiling": "SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY"
+      },
+      {
+        "id": "proof_bundle",
+        "owner": "hawkinsoperations-proof",
+        "artifact_path": "proof/records/lifetime-case-ledger-v1-proof-bundle.json",
+        "what_it_proves": "The proof repo packages the summary, pinned manifest reference, verifier commands, reviewer steps, and exclusions.",
+        "what_it_does_not_prove": "The bundle is not a release, tag, live evidence export, or public-safe promotion.",
+        "current_status": "reviewer packet source only; no release authority",
+        "proof_ceiling": "SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY"
+      },
+      {
+        "id": "badge_status_checks",
+        "owner": "hawkinsoperations-proof",
+        "artifact_path": "README.md and Governance Gate workflow status",
+        "what_it_proves": "Badge routes expose workflow status for the ledger summary and proof bundle verifier jobs.",
+        "what_it_does_not_prove": "Badges are status-only and cannot authorize proof, publication, deployment, or disposition claims.",
+        "current_status": "badge/status references only; not proof authority",
+        "proof_ceiling": "SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY"
+      },
+      {
+        "id": "render_only_downstream_surfaces",
+        "owner": "hawkinsoperations-website and .github",
+        "artifact_path": "website render routes and GitHub reviewer routing",
+        "what_it_proves": "Downstream surfaces can route reviewers to proof-owned artifacts when separately reviewed.",
+        "what_it_does_not_prove": "Render-only and routing surfaces are not proof authority and cannot raise claim ceilings.",
+        "current_status": "render-only or operating-control route; not proof authority",
+        "proof_ceiling": "SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY"
+      }
+    ]
+  },
+  "trust_backup_checklist": [
+    {
+      "id": "summary_verifiable",
+      "status": "PASS_REVIEWABLE",
+      "evidence": "Summary verifier exists at scripts/verify-lifetime-ledger-public-summary.py and the summary records 4 events / 4 cases."
+    },
+    {
+      "id": "bundle_verifiable",
+      "status": "PASS_REVIEWABLE",
+      "evidence": "Bundle verifier exists at scripts/verify-lifetime-ledger-proof-bundle.py and checks the proof bundle against the pinned platform manifest."
+    },
+    {
+      "id": "badges_status_only",
+      "status": "PASS_REVIEWABLE",
+      "evidence": "Badge verifier exists at scripts/verify-lifetime-ledger-badges.py; badges remain status-only indicators."
+    },
+    {
+      "id": "evidence_maps_present",
+      "status": "PASS_REVIEWABLE",
+      "evidence": "Evidence map and branch cleanup map exist under proof/indexes/ and are verifier-backed."
+    },
+    {
+      "id": "cleanup_candidates_classification_only",
+      "status": "PASS_REVIEWABLE",
+      "evidence": "Branch cleanup map is classification-only; branch_deletion_performed remains false."
+    },
+    {
+      "id": "blocked_claims_explicit",
+      "status": "PASS_REVIEWABLE",
+      "evidence": "Blocked claims are explicitly listed in this reviewer proof map."
+    },
+    {
+      "id": "website_render_authority_blocked",
+      "status": "PASS_REVIEWABLE",
+      "evidence": "Website/render surfaces are render-only and not proof authority."
+    },
+    {
+      "id": "project_one_proof_authority_blocked",
+      "status": "PASS_REVIEWABLE",
+      "evidence": "Project #1 is operating control only and not proof authority."
+    }
+  ],
+  "reviewer_click_path": [
+    {
+      "id": "start_reviewer_map",
+      "label": "Start with this map",
+      "artifact_path": "proof/indexes/reviewer-proof-map.md",
+      "reviewer_value": "Read the proof chain, artifact map, blocked claims, and verifier command from one proof-owned reviewer surface."
+    },
+    {
+      "id": "check_public_summary",
+      "label": "Check the ledger summary",
+      "artifact_path": "proof/records/lifetime-case-ledger-v1-public-summary.json",
+      "reviewer_value": "Confirm the 4 events / 4 cases count spine, NOT_PUBLIC_SAFE boundary, and SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY ceiling."
+    },
+    {
+      "id": "check_proof_bundle",
+      "label": "Check the proof bundle",
+      "artifact_path": "proof/records/lifetime-case-ledger-v1-proof-bundle.json",
+      "reviewer_value": "Confirm the summary, corrected platform manifest path, verifier commands, reviewer steps, and excluded material."
+    },
+    {
+      "id": "check_verifier",
+      "label": "Run the verifier",
+      "artifact_path": "scripts/verify-reviewer-proof-map.py",
+      "reviewer_value": "Run the deterministic verifier against the proof map and read-only sibling authority roots."
+    },
+    {
+      "id": "check_blocked_claims",
+      "label": "Review blocked claims",
+      "artifact_path": "proof/indexes/reviewer-proof-map.md#blocked-claims",
+      "reviewer_value": "Confirm runtime, signal, public-safe, production, disposition, case closure, website-authority, badge-authority, and Project #1 authority claims remain blocked."
+    }
+  ],
+  "blocked_claims": [
+    {
+      "claim": "runtime-active public proof",
+      "status": "BLOCKED",
+      "reason": "This map does not prove runtime-active public proof; runtime authority requires separate approved evidence."
+    },
+    {
+      "claim": "signal-observed public proof",
+      "status": "BLOCKED",
+      "reason": "This map does not prove signal-observed public proof; signal truth requires separate approved evidence."
+    },
+    {
+      "claim": "public-safe runtime proof",
+      "status": "BLOCKED",
+      "reason": "This map does not prove public-safe runtime proof; ledger status remains NOT_PUBLIC_SAFE."
+    },
+    {
+      "claim": "production deployment",
+      "status": "BLOCKED",
+      "reason": "This map does not prove production deployment."
+    },
+    {
+      "claim": "SOCaaS deployment",
+      "status": "BLOCKED",
+      "reason": "This map does not prove SOCaaS deployment."
+    },
+    {
+      "claim": "autonomous SOC",
+      "status": "BLOCKED",
+      "reason": "This map does not prove autonomous SOC authority."
+    },
+    {
+      "claim": "AI-approved disposition",
+      "status": "BLOCKED",
+      "reason": "This map does not prove AI-approved disposition."
+    },
+    {
+      "claim": "analyst-approved disposition",
+      "status": "BLOCKED",
+      "reason": "This map does not prove analyst-approved disposition."
+    },
+    {
+      "claim": "case closure",
+      "status": "BLOCKED",
+      "reason": "This map does not prove case closure; closed_case_count remains 0."
+    },
+    {
+      "claim": "Cribl-routed",
+      "status": "BLOCKED",
+      "reason": "This map does not prove Cribl-routed telemetry or public proof."
+    },
+    {
+      "claim": "Wazuh-routed",
+      "status": "BLOCKED",
+      "reason": "This map does not prove Wazuh-routed telemetry or public proof."
+    },
+    {
+      "claim": "AWS-live",
+      "status": "BLOCKED",
+      "reason": "This map does not prove AWS-live runtime state."
+    },
+    {
+      "claim": "fleet-wide",
+      "status": "BLOCKED",
+      "reason": "This map does not prove fleet-wide coverage."
+    },
+    {
+      "claim": "live Splunk firing",
+      "status": "BLOCKED",
+      "reason": "This map does not prove live Splunk firing."
+    },
+    {
+      "claim": "website as proof authority",
+      "status": "BLOCKED",
+      "reason": "Website/render surfaces are not proof authority."
+    },
+    {
+      "claim": "badge as proof authority",
+      "status": "BLOCKED",
+      "reason": "Badges are status-only and not proof authority."
+    },
+    {
+      "claim": "Project #1 as proof authority",
+      "status": "BLOCKED",
+      "reason": "Project #1 is operating control only and not proof authority."
+    }
+  ],
+  "does_not_prove": [
+    "runtime-active public proof is blocked; this map does not prove runtime activity.",
+    "signal-observed public proof is blocked; this map does not prove signal observation.",
+    "public-safe runtime proof is blocked; this map does not prove public-safe runtime evidence.",
+    "production deployment is blocked; this map does not prove deployment.",
+    "SOCaaS deployment is blocked; this map does not prove service availability.",
+    "autonomous SOC is blocked; this map does not prove autonomous authority.",
+    "AI-approved disposition is blocked; this map does not prove AI disposition authority.",
+    "analyst-approved disposition is blocked; this map does not prove analyst disposition authority.",
+    "case closure is blocked; this map does not prove closure.",
+    "Cribl-routed is blocked; this map does not prove Cribl routing.",
+    "Wazuh-routed is blocked; this map does not prove Wazuh routing.",
+    "AWS-live is blocked; this map does not prove live AWS evidence.",
+    "fleet-wide is blocked; this map does not prove fleet coverage.",
+    "live Splunk firing is blocked; this map does not prove live Splunk evidence.",
+    "website as proof authority is blocked; this map treats website surfaces as render-only.",
+    "badge as proof authority is blocked; this map treats badges as status-only.",
+    "Project #1 as proof authority is blocked; this map treats Project #1 as operating control only."
+  ],
+  "verifier_command": "python scripts/verify-reviewer-proof-map.py --platform-root ../hawkinsoperations-platform --github-root ../.github"
+}

--- a/proof/indexes/reviewer-proof-map.md
+++ b/proof/indexes/reviewer-proof-map.md
@@ -1,0 +1,106 @@
+# Reviewer Proof Map
+
+This proof-owned map lets a reviewer inspect the Lifetime Case Ledger proof chain without opening every artifact manually.
+
+It is a reviewer navigation and boundary artifact. It does not promote proof, publish evidence, mutate GitHub Project #1, mutate website, or raise the proof ceiling.
+
+| Field | Current state |
+|---|---|
+| Owner repo | `hawkinsoperations-proof` |
+| Artifact class | proof-owned reviewer map |
+| Ledger summary | `proof/records/lifetime-case-ledger-v1-public-summary.json` |
+| Proof bundle | `proof/records/lifetime-case-ledger-v1-proof-bundle.json` |
+| Ledger count | 4 events / 4 cases |
+| Ledger public-safe status | `NOT_PUBLIC_SAFE` |
+| Proof ceiling | `SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY` |
+| Correct platform manifest path | `../hawkinsoperations-platform/contracts/lifetime-case-ledger-v1-state-manifest.json` |
+| Badges | status-only indicators |
+| Website/render surfaces | render-only reviewer routes |
+| Project #1 | Project #1 is operating control only |
+
+## Reviewer Click Path
+
+| Order | Start here | Why |
+|---|---|---|
+| 1 | Start with this map: `proof/indexes/reviewer-proof-map.md` | Read the proof chain, artifact map, blocked claims, and verifier command from one proof-owned reviewer surface. |
+| 2 | Check `proof/records/lifetime-case-ledger-v1-public-summary.json` | Confirm the 4 events / 4 cases count spine, `NOT_PUBLIC_SAFE` boundary, and `SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY` ceiling. |
+| 3 | Check `proof/records/lifetime-case-ledger-v1-proof-bundle.json` | Confirm the summary, corrected platform manifest path, verifier commands, reviewer steps, and excluded material. |
+| 4 | Run `scripts/verify-reviewer-proof-map.py` | Verify map, Markdown, sibling references, blocked claims, and boundary terms deterministically. |
+| 5 | Review the Blocked Claims section | Confirm runtime, signal, public-safe, production, disposition, case closure, website-authority, badge-authority, and Project #1 authority claims remain blocked. |
+
+## Proof Chain Visual
+
+```mermaid
+flowchart LR
+  A["platform ledger<br/>hawkinsoperations-platform"] --> B["platform state manifest<br/>pinned source truth"]
+  B --> C["proof public summary<br/>4 events / 4 cases"]
+  C --> D["proof bundle<br/>reviewer packet source"]
+  D --> E["badges/status checks<br/>status-only"]
+  E --> F["render-only downstream surfaces<br/>not proof authority"]
+```
+
+| Stage | Owner | Artifact path | What it proves | What it does not prove | Current status | Proof ceiling |
+|---|---|---|---|---|---|---|
+| Platform ledger | `hawkinsoperations-platform` | `evidence/autosoc-case-ledger-v0.sqlite` | A platform ledger seed bridge exists for the 4 events / 4 cases count spine. | Runtime, signal, public proof, deployment, disposition, and closure claims remain blocked. | tracked platform seed bridge; ledger remains `NOT_PUBLIC_SAFE` | `SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY` |
+| Platform state manifest | `hawkinsoperations-platform` | `contracts/lifetime-case-ledger-v1-state-manifest.json` | A pinned source manifest records the ledger count state, repo anchors, and proof boundary inputs. | A manifest is source truth only and does not establish runtime, signal, public-safe, or closure authority. | pinned read-only verifier input | `SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY` |
+| Proof public summary | `hawkinsoperations-proof` | `proof/records/lifetime-case-ledger-v1-public-summary.json` | The proof repo owns a bounded public summary for 4 events / 4 cases, zero public-safe cases, and zero closed cases. | The summary is not runtime evidence and does not approve public proof or case disposition. | source-controlled summary; `NOT_PUBLIC_SAFE` | `SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY` |
+| Proof bundle | `hawkinsoperations-proof` | `proof/records/lifetime-case-ledger-v1-proof-bundle.json` | The proof repo packages the summary, pinned manifest reference, verifier commands, reviewer steps, and exclusions. | The bundle is not a release, tag, live evidence export, or public-safe promotion. | reviewer packet source only; no release authority | `SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY` |
+| Badge/status checks | `hawkinsoperations-proof` | `README.md` and Governance Gate workflow status | Badge routes expose workflow status for the ledger summary and proof bundle verifier jobs. | Badges are status-only and cannot authorize proof, publication, deployment, or disposition claims. | badge/status references only; not proof authority | `SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY` |
+| Render-only downstream surfaces | `hawkinsoperations-website` and `.github` | website render routes and GitHub reviewer routing | Downstream surfaces can route reviewers to proof-owned artifacts when separately reviewed. | Render-only and routing surfaces are not proof authority and cannot raise claim ceilings. | render-only or operating-control route; not proof authority | `SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY` |
+
+## Artifact Map
+
+| Artifact | Owner | Reviewer use | What it proves | What it does not prove |
+|---|---|---|---|---|
+| `proof/records/lifetime-case-ledger-v1-public-summary.json` | proof | Ledger count summary | 4 events / 4 cases and `NOT_PUBLIC_SAFE` boundary are source-controlled in the proof repo. | Runtime, signal, public-safe runtime, deployment, and closure authority remain blocked. |
+| `proof/records/lifetime-case-ledger-v1-proof-bundle.json` | proof | Proof bundle source | Summary, pinned manifest reference, verifier commands, reviewer steps, exclusions, and blocked claims are packaged. | It is not a release, tag, public-safe promotion, or runtime evidence export. |
+| `proof/indexes/lifetime-case-ledger-v1-evidence-map.json` | proof | Evidence preservation map | Canonical, verifier, badge/status, render-only, stale, duplicate, and cleanup-candidate classes are explicit. | It performs no move, copy, delete, archive, or proof promotion. |
+| `proof/indexes/hawkinsoperations-branch-cleanup-map.json` | proof | Branch cleanup map | Branch records are classification-only and deletion remains approval-gated. | It does not delete branches or declare cleanup safe without approval. |
+| `README.md` badge routes | proof | Badge/status route | Workflow status can be checked for ledger summary and bundle verifiers. | Badge as proof authority is blocked; badges are status-only. |
+| Website render routes | website | Downstream reviewer route | A website may route reviewers to proof-owned artifacts after separate review. | Website as proof authority is blocked; website remains render-only. |
+| GitHub Project #1 | GitHub Project | Private operating control | It may track work and gates privately. | Project #1 as proof authority is blocked; Project #1 is operating control only. |
+
+## Trust Backup Checklist
+
+| Check | Status | Evidence |
+|---|---|---|
+| Can the summary be verified? | PASS_REVIEWABLE | `scripts/verify-lifetime-ledger-public-summary.py` checks the public summary against the pinned platform manifest. |
+| Can the bundle be verified? | PASS_REVIEWABLE | `scripts/verify-lifetime-ledger-proof-bundle.py` checks the proof bundle and reviewer steps. |
+| Are badges/status-only? | PASS_REVIEWABLE | `scripts/verify-lifetime-ledger-badges.py` and README wording keep badges status-only. |
+| Are evidence maps present? | PASS_REVIEWABLE | `proof/indexes/lifetime-case-ledger-v1-evidence-map.json` and `proof/indexes/hawkinsoperations-branch-cleanup-map.json` exist. |
+| Are stale/cleanup candidates classification-only? | PASS_REVIEWABLE | The branch cleanup map keeps deletion approval-gated and records no branch deletion. |
+| Are blocked claims explicit? | PASS_REVIEWABLE | The blocked claim table below lists every required blocked claim. |
+| Is website/render authority blocked? | PASS_REVIEWABLE | Website/render surfaces are render-only and not proof authority. |
+| Is Project #1 proof authority blocked? | PASS_REVIEWABLE | Project #1 is operating control only and not proof authority. |
+
+## Blocked Claims
+
+| Claim | Status | Boundary |
+|---|---|---|
+| runtime-active public proof | BLOCKED | This map does not prove runtime-active public proof. |
+| signal-observed public proof | BLOCKED | This map does not prove signal-observed public proof. |
+| public-safe runtime proof | BLOCKED | This map does not prove public-safe runtime proof; ledger status remains `NOT_PUBLIC_SAFE`. |
+| production deployment | BLOCKED | This map does not prove production deployment. |
+| SOCaaS deployment | BLOCKED | This map does not prove SOCaaS deployment. |
+| autonomous SOC | BLOCKED | This map does not prove autonomous SOC authority. |
+| AI-approved disposition | BLOCKED | This map does not prove AI-approved disposition. |
+| analyst-approved disposition | BLOCKED | This map does not prove analyst-approved disposition. |
+| case closure | BLOCKED | This map does not prove case closure; closed-case count remains zero. |
+| Cribl-routed | BLOCKED | This map does not prove Cribl-routed telemetry or public proof. |
+| Wazuh-routed | BLOCKED | This map does not prove Wazuh-routed telemetry or public proof. |
+| AWS-live | BLOCKED | This map does not prove AWS-live runtime state. |
+| fleet-wide | BLOCKED | This map does not prove fleet-wide coverage. |
+| live Splunk firing | BLOCKED | This map does not prove live Splunk firing. |
+| website as proof authority | BLOCKED | Website/render surfaces are not proof authority. |
+| badge as proof authority | BLOCKED | Badges are status-only and not proof authority. |
+| Project #1 as proof authority | BLOCKED | Project #1 is operating control only and not proof authority. |
+
+## Verifier
+
+Run:
+
+```powershell
+python scripts/verify-reviewer-proof-map.py --platform-root ../hawkinsoperations-platform --github-root ../.github
+```
+
+The verifier checks that this map exists, required artifact references exist, 4 events / 4 cases remain present, `NOT_PUBLIC_SAFE` remains present, `SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY` remains present, blocked claims remain blocked, badges remain status-only, website/render surfaces remain render-only, and Project #1 remains operating control only.

--- a/scripts/verify-reviewer-proof-map.py
+++ b/scripts/verify-reviewer-proof-map.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Verify the proof-owned reviewer proof map and claim boundaries."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MAP_PATH = ROOT / "proof" / "indexes" / "reviewer-proof-map.json"
+README_PATH = ROOT / "proof" / "indexes" / "reviewer-proof-map.md"
+
+PROOF_CEILING = "SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY"
+LEDGER_STATUS = "NOT_PUBLIC_SAFE"
+EXPECTED_EVENTS = 4
+EXPECTED_CASES = 4
+CORRECT_PLATFORM_MANIFEST_PATH = "../hawkinsoperations-platform/contracts/lifetime-case-ledger-v1-state-manifest.json"
+STALE_PLATFORM_MANIFEST_TOKENS = (
+    "lifetime-ledger-platform-state-" + "manifest",
+    "evidence/" + "lifetime-ledger-platform-state-" + "manifest.json",
+)
+
+REQUIRED_PROOF_ARTIFACTS = {
+    "proof/records/lifetime-case-ledger-v1-public-summary.json",
+    "proof/records/lifetime-case-ledger-v1-proof-bundle.json",
+    "proof/indexes/lifetime-case-ledger-v1-evidence-map.json",
+    "proof/indexes/hawkinsoperations-branch-cleanup-map.json",
+    "scripts/verify-lifetime-ledger-public-summary.py",
+    "scripts/verify-lifetime-ledger-proof-bundle.py",
+    "scripts/verify-lifetime-ledger-badges.py",
+    "scripts/verify-lifetime-ledger-evidence-map.py",
+    "scripts/verify-hawkinsoperations-branch-cleanup-map.py",
+    "scripts/verify-reviewer-proof-map.py",
+}
+
+REQUIRED_PLATFORM_ARTIFACTS = {
+    "contracts/lifetime-case-ledger-v1-state-manifest.json",
+}
+
+REQUIRED_GITHUB_ARTIFACTS = {
+    "profile/README.md",
+}
+
+REQUIRED_CHAIN_IDS = [
+    "platform_ledger",
+    "platform_state_manifest",
+    "proof_public_summary",
+    "proof_bundle",
+    "badge_status_checks",
+    "render_only_downstream_surfaces",
+]
+
+REQUIRED_BLOCKED_CLAIMS = [
+    "runtime-active public proof",
+    "signal-observed public proof",
+    "public-safe runtime proof",
+    "production deployment",
+    "SOCaaS deployment",
+    "autonomous SOC",
+    "AI-approved disposition",
+    "analyst-approved disposition",
+    "case closure",
+    "Cribl-routed",
+    "Wazuh-routed",
+    "AWS-live",
+    "fleet-wide",
+    "live Splunk firing",
+    "website as proof authority",
+    "badge as proof authority",
+    "Project #1 as proof authority",
+]
+
+REQUIRED_CHECKLIST = [
+    "summary_verifiable",
+    "bundle_verifiable",
+    "badges_status_only",
+    "evidence_maps_present",
+    "cleanup_candidates_classification_only",
+    "blocked_claims_explicit",
+    "website_render_authority_blocked",
+    "project_one_proof_authority_blocked",
+]
+
+REQUIRED_REVIEWER_CLICK_IDS = [
+    "start_reviewer_map",
+    "check_public_summary",
+    "check_proof_bundle",
+    "check_verifier",
+    "check_blocked_claims",
+]
+
+DENIED_TEXT_PATTERNS = [
+    ("local absolute path", re.compile(r"(?i)(?:[A-Z]:\\|\\\\)")),
+    ("private IPv4 address", re.compile(r"\b(?:10|192\.168|172\.(?:1[6-9]|2[0-9]|3[0-1]))\.\d{1,3}\.\d{1,3}\b")),
+    ("secret marker", re.compile(r"(?i)\b(secret|password|credential|api[_-]?key|token)\b")),
+    ("raw private evidence", re.compile(r"(?i)\braw private evidence\b(?!.*(?:excluded|not included|not public-safe|blocked))")),
+]
+
+PROMOTED_CLAIM_PATTERNS = [
+    ("runtime-active public proof", re.compile(r"(?i)\bruntime-active public proof\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
+    ("signal-observed public proof", re.compile(r"(?i)\bsignal-observed public proof\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
+    ("public-safe runtime proof", re.compile(r"(?i)\bpublic-safe runtime proof\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
+    ("production deployment", re.compile(r"(?i)\bproduction deployment\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
+    ("SOCaaS deployment", re.compile(r"(?i)\bSOCaaS deployment\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
+    ("autonomous SOC", re.compile(r"(?i)\bautonomous SOC\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
+    ("AI-approved disposition", re.compile(r"(?i)\bAI-approved disposition\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
+    ("analyst-approved disposition", re.compile(r"(?i)\banalyst-approved disposition\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
+    ("case closure", re.compile(r"(?i)\bcase closure\b(?!.*(?:blocked|not prove|does not prove|not claimed|without))")),
+    ("Cribl-routed", re.compile(r"(?i)\bCribl-routed\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
+    ("Wazuh-routed", re.compile(r"(?i)\bWazuh-routed\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
+    ("AWS-live", re.compile(r"(?i)\bAWS-live\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
+    ("fleet-wide", re.compile(r"(?i)\bfleet-wide\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
+    ("live Splunk firing", re.compile(r"(?i)\blive Splunk firing\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
+    ("website proof authority", re.compile(r"(?i)\bwebsite as proof authority\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
+    ("badge proof authority", re.compile(r"(?i)\bbadge as proof authority\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
+    ("Project proof authority", re.compile(r"(?i)\bProject #1 as proof authority\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
+    ("public safe approved", re.compile(r"(?i)\bPUBLIC_SAFE_APPROVED\b")),
+    ("public proof safe", re.compile(r"(?i)\bPUBLIC_PROOF_SAFE\b")),
+]
+
+
+class VerificationError(Exception):
+    """Raised when reviewer proof map verification fails."""
+
+
+def fail(message: str) -> None:
+    raise VerificationError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        fail(f"missing reviewer proof map: {path.relative_to(ROOT).as_posix()}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"invalid reviewer proof map JSON: {exc}")
+    if not isinstance(data, dict):
+        fail("reviewer proof map root must be an object")
+    return data
+
+
+def scan_text(text: str, label: str) -> None:
+    for token in STALE_PLATFORM_MANIFEST_TOKENS:
+        if token in text:
+            fail(f"{label} contains stale platform manifest reference: {token}")
+    for name, pattern in DENIED_TEXT_PATTERNS:
+        if pattern.search(text):
+            fail(f"{label} contains blocked private marker: {name}")
+    for name, pattern in PROMOTED_CLAIM_PATTERNS:
+        for line in text.splitlines() or [text]:
+            if not pattern.search(line):
+                continue
+            lowered = line.lower()
+            if any(
+                boundary in lowered
+                for boundary in (
+                    "blocked",
+                    "does not prove",
+                    "not proof authority",
+                    "not claimed",
+                    "status-only",
+                    "render-only",
+                    "operating control only",
+                )
+            ):
+                continue
+            fail(f"{label} contains promoted claim wording: {name}")
+
+
+def require_bool_false(value: Any, label: str) -> None:
+    if value is not False:
+        fail(f"{label} must be false")
+
+
+def verify_artifact_paths(paths: list[Any], root: Path, required: set[str], label: str) -> None:
+    found: set[str] = set()
+    for value in paths:
+        if not isinstance(value, str) or not value:
+            fail(f"{label} artifact paths must be non-empty strings")
+        if value.startswith("/") or "\\" in value or re.search(r"(?i)^[A-Z]:", value):
+            fail(f"{label} artifact path must be repo-relative POSIX path: {value}")
+        found.add(value)
+    missing = sorted(required - found)
+    if missing:
+        fail(f"{label} missing required artifact reference: {missing[0]}")
+    for value in required:
+        if not (root / value).exists():
+            fail(f"{label} required artifact does not exist: {value}")
+
+
+def verify_chain(stages: list[Any]) -> None:
+    if not isinstance(stages, list):
+        fail("proof_chain.stages must be a list")
+    ids = [stage.get("id") for stage in stages if isinstance(stage, dict)]
+    if ids != REQUIRED_CHAIN_IDS:
+        fail("proof_chain.stages must preserve the required stage order")
+    for index, stage in enumerate(stages):
+        if not isinstance(stage, dict):
+            fail(f"proof_chain stage {index} must be an object")
+        for field in ("owner", "artifact_path", "what_it_proves", "what_it_does_not_prove", "current_status", "proof_ceiling"):
+            value = stage.get(field)
+            if not isinstance(value, str) or not value.strip():
+                fail(f"proof_chain stage {stage.get('id', index)} missing {field}")
+            scan_text(value, f"proof_chain stage {stage.get('id', index)} {field}")
+        if stage["proof_ceiling"] != PROOF_CEILING:
+            fail(f"proof_chain stage {stage['id']} must keep {PROOF_CEILING}")
+
+
+def verify_checklist(items: list[Any]) -> None:
+    if not isinstance(items, list):
+        fail("trust_backup_checklist must be a list")
+    by_id: dict[str, dict[str, Any]] = {}
+    for item in items:
+        if not isinstance(item, dict):
+            fail("trust_backup_checklist items must be objects")
+        item_id = item.get("id")
+        if not isinstance(item_id, str):
+            fail("trust_backup_checklist item id must be string")
+        by_id[item_id] = item
+        if item.get("status") != "PASS_REVIEWABLE":
+            fail(f"trust_backup_checklist {item_id} must be PASS_REVIEWABLE")
+        evidence = item.get("evidence")
+        if not isinstance(evidence, str) or not evidence.strip():
+            fail(f"trust_backup_checklist {item_id} missing evidence")
+        scan_text(evidence, f"trust_backup_checklist {item_id} evidence")
+    missing = sorted(set(REQUIRED_CHECKLIST) - set(by_id))
+    if missing:
+        fail(f"trust_backup_checklist missing required item: {missing[0]}")
+
+
+def verify_reviewer_click_path(items: list[Any]) -> None:
+    if not isinstance(items, list):
+        fail("reviewer_click_path must be a list")
+    ids = [item.get("id") for item in items if isinstance(item, dict)]
+    if ids != REQUIRED_REVIEWER_CLICK_IDS:
+        fail("reviewer_click_path must preserve the required reviewer order")
+    for item in items:
+        if not isinstance(item, dict):
+            fail("reviewer_click_path items must be objects")
+        for field in ("id", "label", "artifact_path", "reviewer_value"):
+            value = item.get(field)
+            if not isinstance(value, str) or not value.strip():
+                fail(f"reviewer_click_path {item.get('id', '<unknown>')} missing {field}")
+            scan_text(value, f"reviewer_click_path {item.get('id', '<unknown>')} {field}")
+
+
+def verify_blocked_claims(claims: list[Any]) -> None:
+    if not isinstance(claims, list):
+        fail("blocked_claims must be a list")
+    by_claim: dict[str, dict[str, Any]] = {}
+    for entry in claims:
+        if not isinstance(entry, dict):
+            fail("blocked_claims entries must be objects")
+        claim = entry.get("claim")
+        if not isinstance(claim, str):
+            fail("blocked claim must be string")
+        by_claim[claim] = entry
+        if entry.get("status") != "BLOCKED":
+            fail(f"blocked claim must remain BLOCKED: {claim}")
+        if "not prove" not in str(entry.get("reason", "")).lower() and "not proof authority" not in str(entry.get("reason", "")).lower():
+            fail(f"blocked claim needs negative-boundary reason: {claim}")
+    missing = sorted(set(REQUIRED_BLOCKED_CLAIMS) - set(by_claim))
+    if missing:
+        fail(f"blocked_claims missing required claim: {missing[0]}")
+
+
+def verify(data: dict[str, Any], *, platform_root: Path | None, github_root: Path | None) -> dict[str, Any]:
+    if data.get("map_id") != "REVIEWER_PROOF_MAP_V1":
+        fail("unexpected or missing map_id")
+    if data.get("owner_repo") != "hawkinsoperations-proof":
+        fail("owner_repo must be hawkinsoperations-proof")
+    if data.get("proof_ceiling") != PROOF_CEILING:
+        fail(f"proof_ceiling must remain {PROOF_CEILING}")
+    if data.get("ledger_status") != LEDGER_STATUS:
+        fail(f"ledger_status must remain {LEDGER_STATUS}")
+    if data.get("artifact_class") != "proof_owned_reviewer_map":
+        fail("artifact_class must be proof_owned_reviewer_map")
+    if data.get("corrected_platform_manifest_path") != CORRECT_PLATFORM_MANIFEST_PATH:
+        fail("corrected_platform_manifest_path must point to the repo-conventional platform manifest")
+
+    counts = data.get("ledger_summary", {})
+    if not isinstance(counts, dict):
+        fail("ledger_summary must be object")
+    if counts.get("total_ledger_events") != EXPECTED_EVENTS:
+        fail("ledger_summary.total_ledger_events must remain 4")
+    if counts.get("total_cases") != EXPECTED_CASES:
+        fail("ledger_summary.total_cases must remain 4")
+    if counts.get("ledger_public_safe_status") != LEDGER_STATUS:
+        fail(f"ledger_summary.ledger_public_safe_status must remain {LEDGER_STATUS}")
+    require_bool_false(counts.get("case_closure_authority"), "ledger_summary.case_closure_authority")
+
+    boundaries = data.get("authority_boundaries", {})
+    if not isinstance(boundaries, dict):
+        fail("authority_boundaries must be object")
+    for key in (
+        "website_render_surfaces_are_proof_authority",
+        "badges_are_proof_authority",
+        "project_one_is_proof_authority",
+        "github_project_mutation_performed",
+        "proof_promotion_performed",
+    ):
+        require_bool_false(boundaries.get(key), f"authority_boundaries.{key}")
+
+    proof_paths = data.get("required_proof_artifacts")
+    if not isinstance(proof_paths, list):
+        fail("required_proof_artifacts must be list")
+    verify_artifact_paths(proof_paths, ROOT, REQUIRED_PROOF_ARTIFACTS, "proof")
+
+    if platform_root is not None:
+        platform_paths = data.get("read_only_platform_artifacts", [])
+        if not isinstance(platform_paths, list):
+            fail("read_only_platform_artifacts must be list")
+        verify_artifact_paths(platform_paths, platform_root, REQUIRED_PLATFORM_ARTIFACTS, "platform")
+
+    if github_root is not None:
+        github_paths = data.get("read_only_github_artifacts", [])
+        if not isinstance(github_paths, list):
+            fail("read_only_github_artifacts must be list")
+        verify_artifact_paths(github_paths, github_root, REQUIRED_GITHUB_ARTIFACTS, ".github")
+
+    proof_chain = data.get("proof_chain", {})
+    if not isinstance(proof_chain, dict):
+        fail("proof_chain must be object")
+    verify_chain(proof_chain.get("stages", []))
+
+    verify_checklist(data.get("trust_backup_checklist", []))
+    verify_reviewer_click_path(data.get("reviewer_click_path", []))
+    verify_blocked_claims(data.get("blocked_claims", []))
+
+    does_not_prove = data.get("does_not_prove")
+    if not isinstance(does_not_prove, list) or len(does_not_prove) < len(REQUIRED_BLOCKED_CLAIMS):
+        fail("does_not_prove must list the blocked proof boundaries")
+    joined_does_not_prove = "\n".join(str(item) for item in does_not_prove)
+    for claim in REQUIRED_BLOCKED_CLAIMS:
+        if claim not in joined_does_not_prove:
+            fail(f"does_not_prove missing required boundary: {claim}")
+
+    map_text = json.dumps(data, sort_keys=True)
+    scan_text(map_text, "reviewer proof map")
+
+    if not README_PATH.exists():
+        fail(f"missing reviewer proof map markdown: {README_PATH.relative_to(ROOT).as_posix()}")
+    markdown = README_PATH.read_text(encoding="utf-8")
+    scan_text(markdown, README_PATH.relative_to(ROOT).as_posix())
+    for required in (
+        "4 events",
+        "4 cases",
+        LEDGER_STATUS,
+        PROOF_CEILING,
+        "status-only",
+        "render-only",
+        "Project #1 is operating control only",
+        "badge as proof authority",
+        "website as proof authority",
+        CORRECT_PLATFORM_MANIFEST_PATH,
+        "Reviewer Click Path",
+        "Start with this map",
+    ):
+        if required not in markdown:
+            fail(f"reviewer proof map markdown missing required text: {required}")
+
+    return {
+        "map_id": data["map_id"],
+        "proof_ceiling": data["proof_ceiling"],
+        "ledger_status": data["ledger_status"],
+        "blocked_claim_count": len(data["blocked_claims"]),
+        "proof_chain_stage_count": len(proof_chain["stages"]),
+    }
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--map", default=str(MAP_PATH))
+    parser.add_argument("--platform-root")
+    parser.add_argument("--github-root")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        data = load_json(Path(args.map).resolve())
+        result = verify(
+            data,
+            platform_root=Path(args.platform_root).resolve() if args.platform_root else None,
+            github_root=Path(args.github_root).resolve() if args.github_root else None,
+        )
+    except VerificationError as exc:
+        print(f"Reviewer proof map verification failed: {exc}", file=sys.stderr)
+        return 1
+    if args.format == "json":
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print("Reviewer proof map verification passed.")
+        print(f"blocked_claim_count={result['blocked_claim_count']}")
+        print(f"ledger_status={result['ledger_status']}")
+        print(f"proof_ceiling={result['proof_ceiling']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-reviewer-proof-map.py
+++ b/scripts/verify-reviewer-proof-map.py
@@ -101,23 +101,23 @@ DENIED_TEXT_PATTERNS = [
 ]
 
 PROMOTED_CLAIM_PATTERNS = [
-    ("runtime-active public proof", re.compile(r"(?i)\bruntime-active public proof\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
-    ("signal-observed public proof", re.compile(r"(?i)\bsignal-observed public proof\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
-    ("public-safe runtime proof", re.compile(r"(?i)\bpublic-safe runtime proof\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
-    ("production deployment", re.compile(r"(?i)\bproduction deployment\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
-    ("SOCaaS deployment", re.compile(r"(?i)\bSOCaaS deployment\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
-    ("autonomous SOC", re.compile(r"(?i)\bautonomous SOC\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
-    ("AI-approved disposition", re.compile(r"(?i)\bAI-approved disposition\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
-    ("analyst-approved disposition", re.compile(r"(?i)\banalyst-approved disposition\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
-    ("case closure", re.compile(r"(?i)\bcase closure\b(?!.*(?:blocked|not prove|does not prove|not claimed|without))")),
-    ("Cribl-routed", re.compile(r"(?i)\bCribl-routed\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
-    ("Wazuh-routed", re.compile(r"(?i)\bWazuh-routed\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
-    ("AWS-live", re.compile(r"(?i)\bAWS-live\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
-    ("fleet-wide", re.compile(r"(?i)\bfleet-wide\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
-    ("live Splunk firing", re.compile(r"(?i)\blive Splunk firing\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
-    ("website proof authority", re.compile(r"(?i)\bwebsite as proof authority\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
-    ("badge proof authority", re.compile(r"(?i)\bbadge as proof authority\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
-    ("Project proof authority", re.compile(r"(?i)\bProject #1 as proof authority\b(?!.*(?:blocked|not prove|does not prove|not claimed))")),
+    ("runtime-active public proof", re.compile(r"(?i)\bruntime-active public proof\b")),
+    ("signal-observed public proof", re.compile(r"(?i)\bsignal-observed public proof\b")),
+    ("public-safe runtime proof", re.compile(r"(?i)\bpublic-safe runtime proof\b")),
+    ("production deployment", re.compile(r"(?i)\bproduction deployment\b")),
+    ("SOCaaS deployment", re.compile(r"(?i)\bSOCaaS deployment\b")),
+    ("autonomous SOC", re.compile(r"(?i)\bautonomous SOC\b")),
+    ("AI-approved disposition", re.compile(r"(?i)\bAI-approved disposition\b")),
+    ("analyst-approved disposition", re.compile(r"(?i)\banalyst-approved disposition\b")),
+    ("case closure", re.compile(r"(?i)\bcase closure\b")),
+    ("Cribl-routed", re.compile(r"(?i)\bCribl-routed\b")),
+    ("Wazuh-routed", re.compile(r"(?i)\bWazuh-routed\b")),
+    ("AWS-live", re.compile(r"(?i)\bAWS-live\b")),
+    ("fleet-wide", re.compile(r"(?i)\bfleet-wide\b")),
+    ("live Splunk firing", re.compile(r"(?i)\blive Splunk firing\b")),
+    ("website proof authority", re.compile(r"(?i)\bwebsite as proof authority\b")),
+    ("badge proof authority", re.compile(r"(?i)\bbadge as proof authority\b")),
+    ("Project proof authority", re.compile(r"(?i)\bProject #1 as proof authority\b")),
     ("public safe approved", re.compile(r"(?i)\bPUBLIC_SAFE_APPROVED\b")),
     ("public proof safe", re.compile(r"(?i)\bPUBLIC_PROOF_SAFE\b")),
 ]
@@ -143,7 +143,57 @@ def load_json(path: Path) -> dict[str, Any]:
     return data
 
 
-def scan_text(text: str, label: str) -> None:
+PathPart = str | int
+
+
+def json_path(path: tuple[PathPart, ...]) -> str:
+    label = "$"
+    for part in path:
+        if isinstance(part, int):
+            label += f"[{part}]"
+        else:
+            label += f".{part}"
+    return label
+
+
+def promoted_claim_scan_mode(path: tuple[PathPart, ...]) -> str:
+    string_parts = [part for part in path if isinstance(part, str)]
+    last = string_parts[-1] if string_parts else ""
+    first = string_parts[0] if string_parts else ""
+
+    if first == "blocked_claims" and last == "claim":
+        return "blocked_claim_name"
+    if first == "blocked_claims" and last == "reason":
+        return "boundary_text"
+    if first == "does_not_prove":
+        return "boundary_text"
+    if last in {"what_it_does_not_prove", "summary_boundary"}:
+        return "boundary_text"
+    if first == "reviewer_click_path" and last == "reviewer_value":
+        return "boundary_text"
+    if first == "trust_backup_checklist" and last == "evidence":
+        return "boundary_text"
+    return "strict"
+
+
+def has_boundary_context(line: str) -> bool:
+    lowered = line.lower()
+    return any(
+        boundary in lowered
+        for boundary in (
+            "blocked",
+            "does not prove",
+            "not proof authority",
+            "not claimed",
+            "status-only",
+            "render-only",
+            "operating control only",
+            "without explicit human-approved closure artifact",
+        )
+    )
+
+
+def scan_text(text: str, label: str, *, promoted_claim_mode: str = "strict") -> None:
     for token in STALE_PLATFORM_MANIFEST_TOKENS:
         if token in text:
             fail(f"{label} contains stale platform manifest reference: {token}")
@@ -154,21 +204,68 @@ def scan_text(text: str, label: str) -> None:
         for line in text.splitlines() or [text]:
             if not pattern.search(line):
                 continue
-            lowered = line.lower()
-            if any(
-                boundary in lowered
-                for boundary in (
-                    "blocked",
-                    "does not prove",
-                    "not proof authority",
-                    "not claimed",
-                    "status-only",
-                    "render-only",
-                    "operating control only",
-                )
-            ):
+            if promoted_claim_mode == "blocked_claim_name":
+                continue
+            if promoted_claim_mode == "boundary_text" and has_boundary_context(line):
                 continue
             fail(f"{label} contains promoted claim wording: {name}")
+
+
+def scan_json_strings(value: Any, path: tuple[PathPart, ...] = ()) -> None:
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if not isinstance(key, str):
+                fail(f"{json_path(path)} contains non-string object key")
+            scan_json_strings(nested, (*path, key))
+        return
+    if isinstance(value, list):
+        for index, nested in enumerate(value):
+            scan_json_strings(nested, (*path, index))
+        return
+    if isinstance(value, str):
+        scan_text(value, json_path(path), promoted_claim_mode=promoted_claim_scan_mode(path))
+
+
+def run_structural_scan_self_test() -> dict[str, str]:
+    allowed_boundary = {
+        "blocked_claims": [
+            {
+                "claim": "production deployment",
+                "status": "BLOCKED",
+                "reason": "This map does not prove production deployment.",
+            }
+        ],
+        "does_not_prove": [
+            "production deployment is blocked; this map does not prove deployment."
+        ],
+    }
+    scan_json_strings(allowed_boundary)
+
+    bypass_candidate = {
+        "aaa_promoted_claim": "production deployment",
+        "blocked_claims": [
+            {
+                "claim": "production deployment",
+                "status": "BLOCKED",
+                "reason": "This map does not prove production deployment.",
+            }
+        ],
+        "does_not_prove": [
+            "production deployment is blocked; this map does not prove deployment."
+        ],
+    }
+    try:
+        scan_json_strings(bypass_candidate)
+    except VerificationError as exc:
+        message = str(exc)
+        if "$.aaa_promoted_claim" not in message:
+            fail(f"structural scan regression failed at unexpected path: {message}")
+        return {
+            "status": "pass",
+            "negative_case": "arbitrary aaa_promoted_claim production deployment fails closed",
+            "allowed_case": "blocked_claims and does_not_prove boundary wording remains allowed",
+        }
+    fail("structural scan regression did not fail closed for $.aaa_promoted_claim")
 
 
 def require_bool_false(value: Any, label: str) -> None:
@@ -205,7 +302,11 @@ def verify_chain(stages: list[Any]) -> None:
             value = stage.get(field)
             if not isinstance(value, str) or not value.strip():
                 fail(f"proof_chain stage {stage.get('id', index)} missing {field}")
-            scan_text(value, f"proof_chain stage {stage.get('id', index)} {field}")
+            scan_text(
+                value,
+                f"proof_chain stage {stage.get('id', index)} {field}",
+                promoted_claim_mode="boundary_text" if field == "what_it_does_not_prove" else "strict",
+            )
         if stage["proof_ceiling"] != PROOF_CEILING:
             fail(f"proof_chain stage {stage['id']} must keep {PROOF_CEILING}")
 
@@ -226,7 +327,7 @@ def verify_checklist(items: list[Any]) -> None:
         evidence = item.get("evidence")
         if not isinstance(evidence, str) or not evidence.strip():
             fail(f"trust_backup_checklist {item_id} missing evidence")
-        scan_text(evidence, f"trust_backup_checklist {item_id} evidence")
+        scan_text(evidence, f"trust_backup_checklist {item_id} evidence", promoted_claim_mode="boundary_text")
     missing = sorted(set(REQUIRED_CHECKLIST) - set(by_id))
     if missing:
         fail(f"trust_backup_checklist missing required item: {missing[0]}")
@@ -245,7 +346,11 @@ def verify_reviewer_click_path(items: list[Any]) -> None:
             value = item.get(field)
             if not isinstance(value, str) or not value.strip():
                 fail(f"reviewer_click_path {item.get('id', '<unknown>')} missing {field}")
-            scan_text(value, f"reviewer_click_path {item.get('id', '<unknown>')} {field}")
+            scan_text(
+                value,
+                f"reviewer_click_path {item.get('id', '<unknown>')} {field}",
+                promoted_claim_mode="boundary_text" if field == "reviewer_value" else "strict",
+            )
 
 
 def verify_blocked_claims(claims: list[Any]) -> None:
@@ -339,13 +444,13 @@ def verify(data: dict[str, Any], *, platform_root: Path | None, github_root: Pat
         if claim not in joined_does_not_prove:
             fail(f"does_not_prove missing required boundary: {claim}")
 
-    map_text = json.dumps(data, sort_keys=True)
-    scan_text(map_text, "reviewer proof map")
+    run_structural_scan_self_test()
+    scan_json_strings(data)
 
     if not README_PATH.exists():
         fail(f"missing reviewer proof map markdown: {README_PATH.relative_to(ROOT).as_posix()}")
     markdown = README_PATH.read_text(encoding="utf-8")
-    scan_text(markdown, README_PATH.relative_to(ROOT).as_posix())
+    scan_text(markdown, README_PATH.relative_to(ROOT).as_posix(), promoted_claim_mode="boundary_text")
     for required in (
         "4 events",
         "4 cases",
@@ -377,6 +482,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--map", default=str(MAP_PATH))
     parser.add_argument("--platform-root")
     parser.add_argument("--github-root")
+    parser.add_argument("--self-test", action="store_true")
     parser.add_argument("--format", choices=("text", "json"), default="text")
     return parser.parse_args(argv)
 
@@ -384,6 +490,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     try:
+        if args.self_test:
+            result = run_structural_scan_self_test()
+            if args.format == "json":
+                print(json.dumps(result, indent=2, sort_keys=True))
+            else:
+                print("Reviewer proof map structural scan self-test passed.")
+                print(f"negative_case={result['negative_case']}")
+                print(f"allowed_case={result['allowed_case']}")
+            return 0
         data = load_json(Path(args.map).resolve())
         result = verify(
             data,


### PR DESCRIPTION
## Summary of changed files

- `README.md`: adds a reviewer proof map route and bounded proof-chain summary.
- `proof/indexes/reviewer-proof-map.md`: adds the human-readable proof-owned reviewer map, proof-chain visual, artifact map, reviewer click path, trust-backup checklist, blocked claims, and verifier instructions.
- `proof/indexes/reviewer-proof-map.json`: adds the machine-readable reviewer proof map with artifact references, proof-chain stages, blocked claims, does-not-prove boundaries, and reviewer click path.
- `scripts/verify-reviewer-proof-map.py`: adds deterministic verification for reviewer map structure, required artifact references, sibling authority references, blocked claims, proof boundaries, and stale manifest path rejection.

## Stress-test summary

- Confirmed current branch: `feature/reviewer-proof-trust-map`.
- Confirmed only the four approved files were dirty/untracked before staging.
- Stale path scan found no `lifetime-ledger-platform-state-manifest` or `evidence/lifetime-ledger-platform-state-manifest.json` references.
- Verified referenced proof-chain artifacts exist, including the platform manifest at the corrected path.
- Strengthened the verifier to fail closed on stale platform manifest references and missing reviewer click path.
- Added a reviewer click path so a reviewer knows where to start and what to inspect next.
- Ran an in-memory negative stale-manifest check; it failed as expected when the stale manifest path was injected.

## Validation

Passed:

- `git status --short`
- `git diff --check` with README LF-to-CRLF warning only
- `python scripts/verify-reviewer-proof-map.py --platform-root ../hawkinsoperations-platform --github-root ../.github`
- `python scripts/verify-lifetime-ledger-public-summary.py --platform-manifest ../hawkinsoperations-platform/contracts/lifetime-case-ledger-v1-state-manifest.json`
- `python scripts/verify-lifetime-ledger-proof-bundle.py --platform-manifest ../hawkinsoperations-platform/contracts/lifetime-case-ledger-v1-state-manifest.json`
- `python scripts/verify-lifetime-ledger-badges.py`
- `python scripts/verify-lifetime-ledger-evidence-map.py --platform-root ../hawkinsoperations-platform`
- `python scripts/verify-hawkinsoperations-branch-cleanup-map.py`
- `python scripts/verify_detection_proof_status_index.py`
- `python scripts/verify_proof_integrity.py`
- `python -m unittest discover -s tests`
- `python -m json.tool proof/indexes/reviewer-proof-map.json | Out-Null`

Corrected manifest path used:

`../hawkinsoperations-platform/contracts/lifetime-case-ledger-v1-state-manifest.json`

## Proof boundary

- Proof ceiling remains `SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY`.
- Ledger remains `NOT_PUBLIC_SAFE`.
- Badges remain status-only.
- Website/render surfaces remain render-only.
- No runtime truth promotion.
- No signal truth promotion.
- No public-safe promotion.

## Reviewer value

- Reviewer can inspect the proof chain without manually opening every artifact.
- Proof map explains what each stage proves and does not prove.
- Verifier enforces map/boundary consistency.

## Project update packet

- Item title: Proof Trust Backup / Reviewer Proof Map
- Repository: hawkinsoperations-proof
- Lane: Proof / Evidence
- Truth Surface: evidence truth / public proof
- Control Level: soft enforcement; deterministic local verifier added, no workflow mutation unless already present
- Receipt Status: READY_FOR_PR_REVIEW
- Reviewer Facing: yes
- Proof Ceiling: SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY
- Evidence Link: proof/indexes/reviewer-proof-map.md, proof/indexes/reviewer-proof-map.json, scripts/verify-reviewer-proof-map.py
- Next Gate: review/checks/merge approval
- Demo Value: proof chain is visually inspectable without opening every artifact manually
