### PR TITLE
feat: add reviewer metrics proof summary

### DIFF
--- a/proof/indexes/reviewer-metrics-map.md
+++ b/proof/indexes/reviewer-metrics-map.md
@@ -1,0 +1,14 @@
+# Reviewer Metrics Map
+
+This map routes reviewers from each metric to its owning truth surface.
+
+| Metric | Owner | Source artifact | Proof boundary |
+| --- | --- | --- | --- |
+| Lifetime Governed Cases | `hawkinsoperations-platform` | `contracts/lifetime-case-ledger-v1-state-manifest.json` | Strict governed case count only. |
+| Detection Activity Count | `hawkinsoperations-validation` | `activity/detection-activity-ledger-v1.json` | Controlled validation positive fixture matches only. |
+| Validation Case Count | `hawkinsoperations-validation` | `validation/VALIDATION_REGISTRY.yml` | Controlled fixture count only. |
+| Proof Record Count | `hawkinsoperations-proof` | `proof/records/` | Source-controlled proof records only; no claim promotion. |
+| Blocked Claims Count | `hawkinsoperations-proof` and `.github` | `proof/indexes/reviewer-proof-map.json`; `.github#10` | Blocked/prevented promotion visibility only. |
+| Project Board Reconciliation Status | `.github` | `governance/ISSUE_FACTORY_CONTROL_RECEIPTS.md` | Board coordination status only, not proof authority. |
+
+Website rendering is intentionally excluded from v1 implementation while website PR #47 remains open.

--- a/proof/records/reviewer-metrics-pipeline-v1-summary.json
+++ b/proof/records/reviewer-metrics-pipeline-v1-summary.json
@@ -1,0 +1,94 @@
+{
+  "summary_id": "REVIEWER_METRICS_PIPELINE_V1_SUMMARY",
+  "summary_version": "reviewer_metrics_pipeline_v1_proof_summary",
+  "owner_repo": "hawkinsoperations-proof",
+  "artifact_class": "proof_owned_reviewer_metrics_summary",
+  "summary_boundary": "Reviewer-safe source summary for bounded counts only. This does not promote runtime, signal, production, public-safe, disposition, or closure claims.",
+  "source_platform_state": {
+    "repo_name": "hawkinsoperations-platform",
+    "repo_relative_path": "contracts/reviewer-metrics-pipeline-v1-state.json"
+  },
+  "source_artifacts": {
+    "lifetime_case_ledger_summary": "proof/records/lifetime-case-ledger-v1-public-summary.json",
+    "reviewer_proof_map": "proof/indexes/reviewer-proof-map.json",
+    "validation_activity_ledger": "../hawkinsoperations-validation/activity/detection-activity-ledger-v1.json",
+    "platform_metrics_state": "../hawkinsoperations-platform/contracts/reviewer-metrics-pipeline-v1-state.json",
+    "detections_promotion_matrix": "../hawkinsoperations-detections/detections/DETECTION_PROMOTION_MATRIX.yml",
+    "github_control_receipts": "../.github/governance/ISSUE_FACTORY_CONTROL_RECEIPTS.md"
+  },
+  "metrics": {
+    "lifetime_governed_cases": 4,
+    "lifetime_ledger_events": 4,
+    "detection_activity_count": 49,
+    "controlled_validation_fire_count": 49,
+    "validation_case_count": 106,
+    "proof_record_count": 8,
+    "blocked_claim_count": 31,
+    "runtime_public_safe_count": 0,
+    "public_safe_count": 0,
+    "detection_family_count": 6,
+    "controlled_negative_test_count": 57
+  },
+  "project_board_reconciliation_status": {
+    "status": "REPO_BACKED_RECONCILIATION_PLAN_NO_PROJECT_MUTATION",
+    "detections_ledger_eligibility": "REPO_BACKED_BY_DETECTIONS_PR_40",
+    "branch_pr_cleanup": "REPO_BACKED_BY_PROOF_PR_71",
+    "public_safe_blocked_claims": "STANDING_CONTROL_BACKED_BY_GITHUB_ISSUE_10",
+    "reviewer_demo_path": "ACTIVE_ROUTE_BACKED_BY_GITHUB_PR_40_AND_PROOF_PR_72",
+    "github_repo_projects_tab_explanation": "DONE_PROJECT_ROUTING_DOC",
+    "project_metadata_is_proof_authority": false,
+    "github_project_mutation_performed": false
+  },
+  "authority_boundaries": {
+    "validation_owns_activity_counts": true,
+    "platform_owns_lifetime_case_ledger_counts": true,
+    "proof_owns_reviewer_safe_summary": true,
+    "github_owns_reviewer_routing": true,
+    "website_is_proof_authority": false,
+    "github_project_metadata_is_proof_authority": false,
+    "detection_activity_is_governed_case_count": false
+  },
+  "proof_ceiling": "SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY",
+  "public_safe_status": "NOT_PUBLIC_SAFE",
+  "does_not_prove": [
+    "public runtime fires",
+    "signal observation",
+    "public-safe runtime proof",
+    "production deployment",
+    "SOCaaS deployment",
+    "autonomous SOC",
+    "AI-approved disposition",
+    "analyst-approved disposition",
+    "case closure",
+    "GitHub Project proof authority",
+    "website proof authority"
+  ],
+  "blocked_claims": [
+    "runtime-active public proof",
+    "signal-observed public proof",
+    "evidence-linked public proof",
+    "public-safe proof",
+    "public-safe runtime proof",
+    "production-ready",
+    "production deployment",
+    "SOCaaS deployment",
+    "production triage",
+    "fleet-wide deployment",
+    "live Splunk firing",
+    "Cribl-routed",
+    "Wazuh-routed",
+    "AWS-live",
+    "autonomous SOC",
+    "AI-approved disposition",
+    "AI-decided disposition",
+    "analyst-approved disposition",
+    "case closure"
+  ],
+  "reviewer_demo_path": [
+    "Read this summary for the bounded metrics.",
+    "Check platform state at ../hawkinsoperations-platform/contracts/reviewer-metrics-pipeline-v1-state.json.",
+    "Check validation activity at ../hawkinsoperations-validation/activity/detection-activity-ledger-v1.json.",
+    "Check Lifetime Case Ledger summary at proof/records/lifetime-case-ledger-v1-public-summary.json.",
+    "Treat Project board reconciliation as routing/status only, not proof authority."
+  ]
+}

--- a/proof/records/reviewer-metrics-pipeline-v1-summary.md
+++ b/proof/records/reviewer-metrics-pipeline-v1-summary.md
@@ -1,0 +1,30 @@
+# Reviewer Metrics Pipeline v1 Summary
+
+This summary is the proof-owned reviewer surface for the "big number without lying" pipeline.
+
+| Metric | Count | Boundary |
+| --- | ---: | --- |
+| Lifetime Governed Cases | 4 | Strict platform-owned case ledger count. |
+| Lifetime Ledger Events | 4 | Strict platform-owned ledger events. |
+| Detection Activity Count | 49 | Controlled validation positive fixture matches. Not governed cases. |
+| Controlled Validation Fire Count | 49 | Same count as Detection Activity Count in v1. |
+| Validation Case Count | 106 | Positive and negative controlled validation fixtures. |
+| Proof Record Count | 8 | Existing proof-owned record files counted before this summary to avoid self-counting. |
+| Blocked Claim Count | 31 | Unique blocked claims represented across proof summary and reviewer proof map. |
+| Runtime Public-Safe Count | 0 | No runtime-public-safe fire is approved. |
+| Public-Safe Count | 0 | Public-safe status remains blocked. |
+| Detection Family Count | 6 | Detection families represented in the detections promotion matrix. |
+
+## Reviewer Demo Path Status
+
+`REPO_BACKED_RECONCILIATION_PLAN_NO_PROJECT_MUTATION`
+
+- Detections ledger eligibility is repo-backed by detections PR #40.
+- Branch and PR cleanup is repo-backed by proof PR #71.
+- Public-safe blocked claims remain a standing control backed by `.github#10`.
+- Reviewer demo path is backed by `.github` routing and proof PR #72.
+- GitHub Project metadata remains coordination/status only and is not proof authority.
+
+## Boundary
+
+This summary does not prove public runtime fires, signal observation, public-safe runtime proof, production deployment, SOCaaS deployment, autonomous SOC, AI-approved disposition, analyst-approved disposition, case closure, website proof authority, or GitHub Project proof authority.

--- a/scripts/verify-reviewer-metrics-summary.py
+++ b/scripts/verify-reviewer-metrics-summary.py
@@ -41,15 +41,15 @@ def fail(message: str) -> None:
     raise VerificationError(message)
 
 
-def load_json(path: Path) -> dict[str, Any]:
+def load_json(path: Path, label: str = "reviewer metrics summary") -> dict[str, Any]:
     if not path.exists():
-        fail(f"missing reviewer metrics summary: {path}")
+        fail(f"missing {label}: {path}")
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        fail(f"malformed reviewer metrics summary: {exc}")
+        fail(f"malformed {label}: {exc}")
     if not isinstance(data, dict):
-        fail("reviewer metrics summary root must be an object")
+        fail(f"{label} root must be an object")
     return data
 
 
@@ -65,6 +65,40 @@ def scan_value(value: Any, label: str) -> None:
         for name, pattern in DENIED_TEXT:
             if pattern.search(value):
                 fail(f"{label} contains blocked text: {name}")
+
+
+def _source_artifact_path(summary: dict[str, Any], key: str, repo_root: Path) -> Path:
+    source_artifacts = summary.get("source_artifacts")
+    if not isinstance(source_artifacts, dict) or not source_artifacts:
+        fail("source_artifacts must be a non-empty object")
+    value = source_artifacts.get(key)
+    if not isinstance(value, str) or not value:
+        fail(f"source artifact {key} must be a string")
+    path = Path(value)
+    if path.is_absolute():
+        fail(f"source artifact {key} must be repo-relative or sibling-relative")
+    return (repo_root / path).resolve()
+
+
+def platform_metrics_from_summary(summary_path: Path = SUMMARY_PATH, repo_root: Path = ROOT) -> dict[str, int]:
+    summary = load_json(summary_path)
+    platform_state_path = _source_artifact_path(summary, "platform_metrics_state", repo_root)
+    platform_state = load_json(platform_state_path, "platform reviewer metrics state")
+    platform_metrics = platform_state.get("metrics")
+    summary_metrics = summary.get("metrics")
+    if not isinstance(platform_metrics, dict):
+        fail("platform reviewer metrics state metrics must be present")
+    if not isinstance(summary_metrics, dict):
+        fail("summary metrics must be present")
+
+    comparable_keys = sorted(set(summary_metrics).intersection(platform_metrics))
+    expected: dict[str, int] = {}
+    for key in comparable_keys:
+        value = platform_metrics[key]
+        if not isinstance(value, int) or value < 0:
+            fail(f"platform metric {key} must be a non-negative integer")
+        expected[key] = value
+    return expected
 
 
 def verify_summary(summary_path: Path = SUMMARY_PATH, repo_root: Path = ROOT) -> dict[str, Any]:
@@ -111,6 +145,9 @@ def verify_summary(summary_path: Path = SUMMARY_PATH, repo_root: Path = ROOT) ->
         fail("summary must not mutate GitHub Projects")
     if not summary.get("does_not_prove") or not summary.get("blocked_claims"):
         fail("does_not_prove and blocked_claims must be populated")
+    for key, expected in platform_metrics_from_summary(summary_path, repo_root).items():
+        if metrics.get(key) != expected:
+            fail(f"{key} platform metric mismatch: expected {expected}, found {metrics.get(key)}")
 
     return {
         "status": "pass",

--- a/scripts/verify-reviewer-metrics-summary.py
+++ b/scripts/verify-reviewer-metrics-summary.py
@@ -101,6 +101,25 @@ def platform_metrics_from_summary(summary_path: Path = SUMMARY_PATH, repo_root: 
     return expected
 
 
+def project_reconciliation_from_summary(summary_path: Path = SUMMARY_PATH, repo_root: Path = ROOT) -> dict[str, bool]:
+    summary = load_json(summary_path)
+    receipt_path = _source_artifact_path(summary, "github_control_receipts", repo_root)
+    text = receipt_path.read_text(encoding="utf-8")
+    lowered = text.lower()
+    reconciliation = summary.get("project_board_reconciliation_status")
+    if not isinstance(reconciliation, dict):
+        fail("project_board_reconciliation_status must be present")
+
+    return {
+        "standing_issue_8_present": "#8" in text and "standing control" in lowered,
+        "standing_issue_10_present": "#10" in text and "blocked claims" in lowered,
+        "project_2_route_present": "project #2" in lowered,
+        "report_only_boundary_present": "report_only" in lowered or "not proof" in lowered,
+        "project_metadata_is_proof_authority": reconciliation.get("project_metadata_is_proof_authority") is True,
+        "github_project_mutation_performed": reconciliation.get("github_project_mutation_performed") is True,
+    }
+
+
 def verify_summary(summary_path: Path = SUMMARY_PATH, repo_root: Path = ROOT) -> dict[str, Any]:
     summary = load_json(summary_path)
     scan_value(summary, "reviewer metrics summary")
@@ -143,11 +162,21 @@ def verify_summary(summary_path: Path = SUMMARY_PATH, repo_root: Path = ROOT) ->
         fail("project_board_reconciliation_status must be present")
     if reconciliation.get("github_project_mutation_performed") is not False:
         fail("summary must not mutate GitHub Projects")
+    if reconciliation.get("project_metadata_is_proof_authority") is not False:
+        fail("Project metadata must remain non-authoritative")
     if not summary.get("does_not_prove") or not summary.get("blocked_claims"):
         fail("does_not_prove and blocked_claims must be populated")
     for key, expected in platform_metrics_from_summary(summary_path, repo_root).items():
         if metrics.get(key) != expected:
             fail(f"{key} platform metric mismatch: expected {expected}, found {metrics.get(key)}")
+    project_reconciliation = project_reconciliation_from_summary(summary_path, repo_root)
+    for key in ("standing_issue_8_present", "standing_issue_10_present", "project_2_route_present", "report_only_boundary_present"):
+        if project_reconciliation[key] is not True:
+            fail(f"project reconciliation source missing boundary: {key}")
+    if project_reconciliation["project_metadata_is_proof_authority"] is not False:
+        fail("Project metadata must remain non-authoritative")
+    if project_reconciliation["github_project_mutation_performed"] is not False:
+        fail("summary must not mutate GitHub Projects")
 
     return {
         "status": "pass",

--- a/scripts/verify-reviewer-metrics-summary.py
+++ b/scripts/verify-reviewer-metrics-summary.py
@@ -19,6 +19,7 @@ REQUIRED_METRICS = {
     "lifetime_ledger_events",
     "detection_activity_count",
     "controlled_validation_fire_count",
+    "controlled_negative_test_count",
     "validation_case_count",
     "proof_record_count",
     "blocked_claim_count",
@@ -91,7 +92,10 @@ def platform_metrics_from_summary(summary_path: Path = SUMMARY_PATH, repo_root: 
     if not isinstance(summary_metrics, dict):
         fail("summary metrics must be present")
 
-    comparable_keys = sorted(set(summary_metrics).intersection(platform_metrics))
+    missing_platform_keys = sorted(set(summary_metrics) - set(platform_metrics))
+    if missing_platform_keys:
+        fail(f"platform metrics missing summarized keys: {missing_platform_keys}")
+    comparable_keys = sorted(summary_metrics)
     expected: dict[str, int] = {}
     for key in comparable_keys:
         value = platform_metrics[key]

--- a/scripts/verify-reviewer-metrics-summary.py
+++ b/scripts/verify-reviewer-metrics-summary.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Verify the proof-owned reviewer metrics summary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SUMMARY_PATH = ROOT / "proof" / "records" / "reviewer-metrics-pipeline-v1-summary.json"
+
+REQUIRED_METRICS = {
+    "lifetime_governed_cases",
+    "lifetime_ledger_events",
+    "detection_activity_count",
+    "controlled_validation_fire_count",
+    "validation_case_count",
+    "proof_record_count",
+    "blocked_claim_count",
+    "runtime_public_safe_count",
+    "public_safe_count",
+    "detection_family_count",
+}
+DENIED_TEXT = [
+    ("C:\\Raylee\\Work", re.compile(r"C:\\Raylee\\Work", re.IGNORECASE)),
+    ("private IPv4 address", re.compile(r"\b(?:10|192\.168|172\.(?:1[6-9]|2[0-9]|3[0-1]))\.\d{1,3}\.\d{1,3}\b")),
+    ("secret marker", re.compile(r"\b(secret|password|credential|api[_-]?key|token)\b", re.IGNORECASE)),
+]
+
+
+class VerificationError(Exception):
+    """Raised when reviewer metrics summary violates the proof boundary."""
+
+
+def fail(message: str) -> None:
+    raise VerificationError(message)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        fail(f"missing reviewer metrics summary: {path}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"malformed reviewer metrics summary: {exc}")
+    if not isinstance(data, dict):
+        fail("reviewer metrics summary root must be an object")
+    return data
+
+
+def scan_value(value: Any, label: str) -> None:
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            scan_value(key, label)
+            scan_value(nested, label)
+    elif isinstance(value, list):
+        for nested in value:
+            scan_value(nested, label)
+    elif isinstance(value, str):
+        for name, pattern in DENIED_TEXT:
+            if pattern.search(value):
+                fail(f"{label} contains blocked text: {name}")
+
+
+def verify_summary(summary_path: Path = SUMMARY_PATH, repo_root: Path = ROOT) -> dict[str, Any]:
+    summary = load_json(summary_path)
+    scan_value(summary, "reviewer metrics summary")
+
+    if summary.get("owner_repo") != "hawkinsoperations-proof":
+        fail("owner_repo must be hawkinsoperations-proof")
+    if summary.get("public_safe_status") != "NOT_PUBLIC_SAFE":
+        fail("public_safe_status must be NOT_PUBLIC_SAFE")
+    if summary.get("proof_ceiling") != "SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY":
+        fail("proof_ceiling must remain SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY")
+
+    metrics = summary.get("metrics")
+    if not isinstance(metrics, dict):
+        fail("metrics must be present")
+    missing = REQUIRED_METRICS - set(metrics)
+    if missing:
+        fail(f"metrics missing fields: {sorted(missing)}")
+    for key in REQUIRED_METRICS:
+        if not isinstance(metrics[key], int) or metrics[key] < 0:
+            fail(f"{key} must be a non-negative integer")
+    if metrics["detection_activity_count"] <= metrics["lifetime_governed_cases"]:
+        fail("detection activity count must remain visibly broader than governed cases")
+    if metrics["detection_activity_count"] != metrics["controlled_validation_fire_count"]:
+        fail("v1 detection activity count must equal controlled validation fire count")
+    if metrics["runtime_public_safe_count"] != 0 or metrics["public_safe_count"] != 0:
+        fail("summary must not claim public-safe counts")
+
+    authority = summary.get("authority_boundaries")
+    if not isinstance(authority, dict):
+        fail("authority_boundaries must be present")
+    if authority.get("website_is_proof_authority") is not False:
+        fail("website must remain render-only and not proof authority")
+    if authority.get("github_project_metadata_is_proof_authority") is not False:
+        fail("GitHub Project metadata must not be proof authority")
+    if authority.get("detection_activity_is_governed_case_count") is not False:
+        fail("detection activity must not be governed case count")
+
+    reconciliation = summary.get("project_board_reconciliation_status")
+    if not isinstance(reconciliation, dict):
+        fail("project_board_reconciliation_status must be present")
+    if reconciliation.get("github_project_mutation_performed") is not False:
+        fail("summary must not mutate GitHub Projects")
+    if not summary.get("does_not_prove") or not summary.get("blocked_claims"):
+        fail("does_not_prove and blocked_claims must be populated")
+
+    return {
+        "status": "pass",
+        "summary_path": str(summary_path.relative_to(repo_root)) if summary_path.is_relative_to(repo_root) else str(summary_path),
+        "metrics": metrics,
+        "proof_ceiling": summary["proof_ceiling"],
+        "public_safe_status": summary["public_safe_status"],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--summary", type=Path, default=SUMMARY_PATH)
+    parser.add_argument("--format", choices={"text", "json"}, default="text")
+    args = parser.parse_args(argv)
+    try:
+        result = verify_summary(args.summary, ROOT)
+    except VerificationError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+    if args.format == "json":
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print("PASS: reviewer metrics summary is proof-bounded")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_verify_reviewer_metrics_summary.py
+++ b/tests/test_verify_reviewer_metrics_summary.py
@@ -36,6 +36,16 @@ class ReviewerMetricsSummaryTests(unittest.TestCase):
         for key, expected in platform_metrics.items():
             self.assertEqual(summary_metrics[key], expected)
 
+    def test_project_reconciliation_is_backed_by_github_receipt_source(self) -> None:
+        reconciliation = verifier.project_reconciliation_from_summary(SUMMARY_PATH, ROOT)
+
+        self.assertTrue(reconciliation["standing_issue_8_present"])
+        self.assertTrue(reconciliation["standing_issue_10_present"])
+        self.assertTrue(reconciliation["project_2_route_present"])
+        self.assertTrue(reconciliation["report_only_boundary_present"])
+        self.assertFalse(reconciliation["project_metadata_is_proof_authority"])
+        self.assertFalse(reconciliation["github_project_mutation_performed"])
+
     def test_summary_blocks_website_or_project_board_proof_authority(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "summary.json"

--- a/tests/test_verify_reviewer_metrics_summary.py
+++ b/tests/test_verify_reviewer_metrics_summary.py
@@ -29,6 +29,13 @@ class ReviewerMetricsSummaryTests(unittest.TestCase):
         self.assertGreater(metrics["detection_activity_count"], metrics["lifetime_governed_cases"])
         self.assertEqual(result["public_safe_status"], "NOT_PUBLIC_SAFE")
 
+    def test_summary_metrics_match_platform_state(self) -> None:
+        platform_metrics = verifier.platform_metrics_from_summary(SUMMARY_PATH, ROOT)
+        summary_metrics = json.loads(SUMMARY_PATH.read_text(encoding="utf-8"))["metrics"]
+
+        for key, expected in platform_metrics.items():
+            self.assertEqual(summary_metrics[key], expected)
+
     def test_summary_blocks_website_or_project_board_proof_authority(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "summary.json"

--- a/tests/test_verify_reviewer_metrics_summary.py
+++ b/tests/test_verify_reviewer_metrics_summary.py
@@ -18,43 +18,107 @@ spec.loader.exec_module(verifier)
 
 
 class ReviewerMetricsSummaryTests(unittest.TestCase):
-    def test_summary_exposes_big_number_without_promoting_case_count(self) -> None:
-        result = verifier.verify_summary(SUMMARY_PATH, ROOT)
+    def write_summary_source_fixtures(self, root: Path, summary: dict) -> Path:
+        summary_path = root / "proof" / "records" / "reviewer-metrics-pipeline-v1-summary.json"
+        summary_path.parent.mkdir(parents=True)
+        summary_path.write_text(json.dumps(summary), encoding="utf-8")
 
-        metrics = result["metrics"]
-        self.assertEqual(metrics["lifetime_governed_cases"], 4)
-        self.assertEqual(metrics["detection_activity_count"], 49)
-        self.assertEqual(metrics["validation_case_count"], 106)
-        self.assertEqual(metrics["proof_record_count"], 8)
-        self.assertGreater(metrics["detection_activity_count"], metrics["lifetime_governed_cases"])
-        self.assertEqual(result["public_safe_status"], "NOT_PUBLIC_SAFE")
+        platform_path = root / summary["source_artifacts"]["platform_metrics_state"]
+        platform_path.parent.mkdir(parents=True)
+        platform_path.write_text(
+            json.dumps(
+                {
+                    "metrics": dict(summary["metrics"]),
+                    "proof_ceiling": "SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY",
+                    "public_safe_status": "NOT_PUBLIC_SAFE",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        receipt_path = root / summary["source_artifacts"]["github_control_receipts"]
+        receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        receipt_path.write_text(
+            "#8 standing control\n#10 blocked claims\nProject #2\nREPORT_ONLY not proof\n",
+            encoding="utf-8",
+        )
+        return summary_path
+
+    def test_summary_exposes_big_number_without_promoting_case_count(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            summary = json.loads(SUMMARY_PATH.read_text(encoding="utf-8"))
+            summary["source_artifacts"]["platform_metrics_state"] = "sources/platform-state.json"
+            summary["source_artifacts"]["github_control_receipts"] = "sources/github/receipts.md"
+            summary_path = self.write_summary_source_fixtures(root, summary)
+
+            result = verifier.verify_summary(summary_path, root)
+
+            metrics = result["metrics"]
+            self.assertEqual(metrics["lifetime_governed_cases"], 4)
+            self.assertEqual(metrics["detection_activity_count"], 49)
+            self.assertEqual(metrics["validation_case_count"], 106)
+            self.assertEqual(metrics["proof_record_count"], 8)
+            self.assertGreater(metrics["detection_activity_count"], metrics["lifetime_governed_cases"])
+            self.assertEqual(result["public_safe_status"], "NOT_PUBLIC_SAFE")
 
     def test_summary_metrics_match_platform_state(self) -> None:
-        platform_metrics = verifier.platform_metrics_from_summary(SUMMARY_PATH, ROOT)
-        summary_metrics = json.loads(SUMMARY_PATH.read_text(encoding="utf-8"))["metrics"]
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            summary = json.loads(SUMMARY_PATH.read_text(encoding="utf-8"))
+            summary["source_artifacts"]["platform_metrics_state"] = "sources/platform-state.json"
+            summary["source_artifacts"]["github_control_receipts"] = "sources/github/receipts.md"
+            summary_path = self.write_summary_source_fixtures(root, summary)
 
-        for key, expected in platform_metrics.items():
-            self.assertEqual(summary_metrics[key], expected)
+            platform_metrics = verifier.platform_metrics_from_summary(summary_path, root)
+
+            self.assertEqual(set(platform_metrics), set(summary["metrics"]))
+            for key, expected in platform_metrics.items():
+                self.assertEqual(summary["metrics"][key], expected)
+
+    def test_summary_fails_when_platform_state_omits_summarized_metric(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            summary = json.loads(SUMMARY_PATH.read_text(encoding="utf-8"))
+            summary["source_artifacts"]["platform_metrics_state"] = "sources/platform-state.json"
+            summary["source_artifacts"]["github_control_receipts"] = "sources/github/receipts.md"
+            summary_path = self.write_summary_source_fixtures(root, summary)
+            platform_path = root / summary["source_artifacts"]["platform_metrics_state"]
+            platform_state = json.loads(platform_path.read_text(encoding="utf-8"))
+            del platform_state["metrics"]["validation_case_count"]
+            platform_path.write_text(json.dumps(platform_state), encoding="utf-8")
+
+            with self.assertRaisesRegex(verifier.VerificationError, "platform metrics missing summarized keys"):
+                verifier.verify_summary(summary_path, root)
 
     def test_project_reconciliation_is_backed_by_github_receipt_source(self) -> None:
-        reconciliation = verifier.project_reconciliation_from_summary(SUMMARY_PATH, ROOT)
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            summary = json.loads(SUMMARY_PATH.read_text(encoding="utf-8"))
+            summary["source_artifacts"]["platform_metrics_state"] = "sources/platform-state.json"
+            summary["source_artifacts"]["github_control_receipts"] = "sources/github/receipts.md"
+            summary_path = self.write_summary_source_fixtures(root, summary)
 
-        self.assertTrue(reconciliation["standing_issue_8_present"])
-        self.assertTrue(reconciliation["standing_issue_10_present"])
-        self.assertTrue(reconciliation["project_2_route_present"])
-        self.assertTrue(reconciliation["report_only_boundary_present"])
-        self.assertFalse(reconciliation["project_metadata_is_proof_authority"])
-        self.assertFalse(reconciliation["github_project_mutation_performed"])
+            reconciliation = verifier.project_reconciliation_from_summary(summary_path, root)
+
+            self.assertTrue(reconciliation["standing_issue_8_present"])
+            self.assertTrue(reconciliation["standing_issue_10_present"])
+            self.assertTrue(reconciliation["project_2_route_present"])
+            self.assertTrue(reconciliation["report_only_boundary_present"])
+            self.assertFalse(reconciliation["project_metadata_is_proof_authority"])
+            self.assertFalse(reconciliation["github_project_mutation_performed"])
 
     def test_summary_blocks_website_or_project_board_proof_authority(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "summary.json"
+            root = Path(tmp)
             data = json.loads(SUMMARY_PATH.read_text(encoding="utf-8"))
+            data["source_artifacts"]["platform_metrics_state"] = "sources/platform-state.json"
+            data["source_artifacts"]["github_control_receipts"] = "sources/github/receipts.md"
             data["authority_boundaries"]["website_is_proof_authority"] = True
-            path.write_text(json.dumps(data), encoding="utf-8")
+            path = self.write_summary_source_fixtures(root, data)
 
             with self.assertRaisesRegex(verifier.VerificationError, "website must remain render-only"):
-                verifier.verify_summary(path, ROOT)
+                verifier.verify_summary(path, root)
 
 
 if __name__ == "__main__":

--- a/tests/test_verify_reviewer_metrics_summary.py
+++ b/tests/test_verify_reviewer_metrics_summary.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "verify-reviewer-metrics-summary.py"
+SUMMARY_PATH = ROOT / "proof" / "records" / "reviewer-metrics-pipeline-v1-summary.json"
+
+spec = importlib.util.spec_from_file_location("verify_reviewer_metrics_summary", SCRIPT_PATH)
+verifier = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(verifier)
+
+
+class ReviewerMetricsSummaryTests(unittest.TestCase):
+    def test_summary_exposes_big_number_without_promoting_case_count(self) -> None:
+        result = verifier.verify_summary(SUMMARY_PATH, ROOT)
+
+        metrics = result["metrics"]
+        self.assertEqual(metrics["lifetime_governed_cases"], 4)
+        self.assertEqual(metrics["detection_activity_count"], 49)
+        self.assertEqual(metrics["validation_case_count"], 106)
+        self.assertEqual(metrics["proof_record_count"], 8)
+        self.assertGreater(metrics["detection_activity_count"], metrics["lifetime_governed_cases"])
+        self.assertEqual(result["public_safe_status"], "NOT_PUBLIC_SAFE")
+
+    def test_summary_blocks_website_or_project_board_proof_authority(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "summary.json"
+            data = json.loads(SUMMARY_PATH.read_text(encoding="utf-8"))
+            data["authority_boundaries"]["website_is_proof_authority"] = True
+            path.write_text(json.dumps(data), encoding="utf-8")
+
+            with self.assertRaisesRegex(verifier.VerificationError, "website must remain render-only"):
+                verifier.verify_summary(path, ROOT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds proof-owned reviewer-safe metrics rollup.

## Metrics
- Lifetime Governed Cases: 4
- Detection Activity: 49
- Validation Cases: 106
- Proof Records: 8
- Blocked Claims: 31
- Project Board reconciliation: `REPO_BACKED_RECONCILIATION_PLAN_NO_PROJECT_MUTATION`

## Boundary
Proof summary is a reviewer-safe count rollup only. It does not prove public runtime fires, signal observation, production deployment, autonomous SOC, AI or analyst disposition authority, public-safe status, or GitHub Project proof authority.

## Validation
- `git diff --check`: pass
- `python -m unittest tests.test_verify_reviewer_metrics_summary`: 4 tests, OK
- `python scripts\verify-reviewer-metrics-summary.py --format json`: pass; `lifetime_governed_cases=4`, `detection_activity_count=49`, `validation_case_count=106`, `proof_record_count=8`, `blocked_claim_count=31`, `public_safe_count=0`
- `python scripts\verify-reviewer-proof-map.py --platform-root ..\hawkinsoperations-platform --github-root ..\.github`: pass; `blocked_claim_count=17`, `ledger_status=NOT_PUBLIC_SAFE`, `proof_ceiling=SCHEMA_CONTRACT_VERIFIER_EXISTS_ONLY`
- `python scripts\verify_proof_integrity.py`: pass
- Python in-memory compile for `scripts\verify-reviewer-metrics-summary.py`: pass
- Changed-file scan: no stale `C:\Raylee\Work`, Windows profile path, private data path, private IP, token/secret assignment, or promoted-claim hits. Blocked-claim terms are negative-boundary context.

## Merge Authority
Merge requires Raylee approval. Green checks and Codex review are not merge authority.