### PR TITLE
proof: preserve runtime route proof v1 private candidate

### DIFF
--- a/.github/workflows/governance-gate.yml
+++ b/.github/workflows/governance-gate.yml
@@ -117,3 +117,11 @@ jobs:
       - name: Verify HawkinsOperations branch cleanup governance map
         run: |
           python scripts/verify-hawkinsoperations-branch-cleanup-map.py --format json >/dev/null
+
+  runtime-route-proof-v1-private-candidate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify Runtime Route Proof v1 private candidate map
+        run: |
+          python scripts/verify-runtime-route-proof-v1-private-candidate-map.py >/dev/null

--- a/proof/indexes/runtime-route-proof-v1-private-candidate-map.json
+++ b/proof/indexes/runtime-route-proof-v1-private-candidate-map.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": "runtime-route-proof-v1-private-candidate-map-v1",
+  "map_id": "runtime-route-proof-v1-private-candidate-map",
+  "record_path": "proof/records/RUNTIME-ROUTE-PROOF-V1-PRIVATE-CANDIDATE.md",
+  "marker_id": "HO-RUNTIME-V1-20260601T120922Z-BATCH764",
+  "private_route": [
+    "Wazuh",
+    "Cribl",
+    "Splunk"
+  ],
+  "receipts": {
+    "wazuh": "PASS",
+    "cribl": "PASS",
+    "splunk": "PASS"
+  },
+  "deterministic_verifier_status": "PASS_ROUTE_RECEIPTS",
+  "manifest_verified": true,
+  "lifetime_governed_cases": 4,
+  "public_safe_count": 0,
+  "public_safe_status": "NOT_PUBLIC_SAFE",
+  "proof_ceiling": "PRIVATE_RUNTIME_ROUTE_PROOF_V1_CANDIDATE",
+  "preservation_ceiling": "PRIVATE_RUNTIME_ROUTE_PROOF_V1_CANDIDATE_PRESERVED",
+  "reviewer_safe_packet": {
+    "filename": "HO-RUNTIME-ROUTE-PROOF-V1-PRIVATE-REVIEWER-SAFE-2026-06-01.zip",
+    "sha256": "3a1d4472bffcce68cff6e101c54e06b5a67528338bda174e6fef209fa9b1b278",
+    "raw_private_evidence_in_repo": false
+  },
+  "claim_boundary": {
+    "public_safe_runtime_proof": false,
+    "production_soc_operation": false,
+    "autonomous_soc_operation": false,
+    "ai_decided_disposition": false,
+    "lifetime_governed_case_mutation": false,
+    "public_publication_approved": false,
+    "human_review_required": true
+  },
+  "blocked_claims": [
+    "public-safe runtime proof",
+    "production SOC operation",
+    "autonomous SOC operation",
+    "AI-decided disposition",
+    "analyst-approved disposition",
+    "Lifetime Governed Case mutation",
+    "broad ingestion",
+    "public publication approval"
+  ]
+}

--- a/proof/indexes/runtime-route-proof-v1-private-candidate-map.md
+++ b/proof/indexes/runtime-route-proof-v1-private-candidate-map.md
@@ -1,0 +1,38 @@
+# Runtime Route Proof v1 Private Candidate Map
+
+## Status
+
+| Field | Value |
+|---|---|
+| Map ID | runtime-route-proof-v1-private-candidate-map |
+| Record | `proof/records/RUNTIME-ROUTE-PROOF-V1-PRIVATE-CANDIDATE.md` |
+| JSON map | `proof/indexes/runtime-route-proof-v1-private-candidate-map.json` |
+| Marker ID | HO-RUNTIME-V1-20260601T120922Z-BATCH764 |
+| Private route | Wazuh -> Cribl -> Splunk |
+| Deterministic verifier | PASS_ROUTE_RECEIPTS |
+| Manifest verified | true |
+| Proof ceiling | PRIVATE_RUNTIME_ROUTE_PROOF_V1_CANDIDATE |
+| Preservation ceiling | PRIVATE_RUNTIME_ROUTE_PROOF_V1_CANDIDATE_PRESERVED |
+| Public-safe status | NOT_PUBLIC_SAFE |
+| Lifetime Governed Cases | 4 |
+| Public-safe count | 0 |
+
+## Route
+
+| Hop | Private receipt status | Repo boundary |
+|---|---|---|
+| Wazuh | PASS | Summary only; raw receipt excluded. |
+| Cribl | PASS | Summary only; raw receipt excluded. |
+| Splunk | PASS | Summary only; raw receipt excluded. |
+
+## Reviewer-Safe Packet Reference
+
+| Field | Value |
+|---|---|
+| Packet filename | HO-RUNTIME-ROUTE-PROOF-V1-PRIVATE-REVIEWER-SAFE-2026-06-01.zip |
+| Packet SHA256 | 3a1d4472bffcce68cff6e101c54e06b5a67528338bda174e6fef209fa9b1b278 |
+| Raw private evidence in repo | false |
+
+## Boundary
+
+This map routes reviewers to the proof candidate record and the platform packet verifier contract. It does not include raw runtime evidence and does not prove public-safe runtime proof, production operation, autonomous SOC behavior, AI-decided disposition, or any Lifetime Governed Case mutation. It does not mutate Lifetime Governed Cases.

--- a/proof/records/RUNTIME-ROUTE-PROOF-V1-PRIVATE-CANDIDATE.md
+++ b/proof/records/RUNTIME-ROUTE-PROOF-V1-PRIVATE-CANDIDATE.md
@@ -1,0 +1,74 @@
+# Runtime Route Proof v1 Private Candidate
+
+## Status
+
+| Field | Value |
+|---|---|
+| Record ID | RUNTIME-ROUTE-PROOF-V1-PRIVATE-CANDIDATE |
+| Marker ID | HO-RUNTIME-V1-20260601T120922Z-BATCH764 |
+| Private route | Wazuh -> Cribl -> Splunk |
+| Wazuh receipt | PASS |
+| Cribl receipt | PASS |
+| Splunk receipt | PASS |
+| Deterministic verifier | PASS_ROUTE_RECEIPTS |
+| Manifest verified | true |
+| Lifetime Governed Cases | 4 |
+| Public-safe count | 0 |
+| Public-safe status | NOT_PUBLIC_SAFE |
+| Proof ceiling | PRIVATE_RUNTIME_ROUTE_PROOF_V1_CANDIDATE |
+| Preservation ceiling | PRIVATE_RUNTIME_ROUTE_PROOF_V1_CANDIDATE_PRESERVED |
+| AI-decided disposition | false |
+
+## Evidence Summary
+
+This record preserves a private controlled runtime route receipt correlation for Runtime Route Proof v1. The successful marker `HO-RUNTIME-V1-20260601T120922Z-BATCH764` produced correlated Wazuh, Cribl, and Splunk receipt status after delayed read-only source-attribution verification.
+
+The private route proof is represented in this repository only through reviewer-safe summary facts and hashes. Raw private runtime receipts, raw payloads, local evidence paths, private host details, tokens, secrets, and internal network details are intentionally excluded from this repository.
+
+## Reviewer-Safe Packet
+
+| Field | Value |
+|---|---|
+| Packet filename | HO-RUNTIME-ROUTE-PROOF-V1-PRIVATE-REVIEWER-SAFE-2026-06-01.zip |
+| Packet SHA256 | 3a1d4472bffcce68cff6e101c54e06b5a67528338bda174e6fef209fa9b1b278 |
+| Packet custody | Private operator evidence store; repo contains no raw packet contents. |
+| Packet status | PRIVATE_REVIEWER_SAFE_SUMMARY |
+
+## What This Proves
+
+- A successful private Runtime Route Proof v1 marker exists.
+- Wazuh, Cribl, and Splunk private route receipts correlate for the marker.
+- The deterministic route verifier passed with `PASS_ROUTE_RECEIPTS`.
+- The private receipt manifest verified successfully.
+- Lifetime Governed Cases remained 4.
+- Public-safe count remained 0.
+- Reviewer-safe packet material exists outside this repository and has a pinned SHA256.
+
+## What This Does Not Prove
+
+- It does not prove public-safe runtime proof.
+- It does not prove production SOC operation.
+- It does not prove autonomous SOC operation.
+- It does not prove broad Wazuh forwarding, broad Cribl routing, or broad Splunk ingestion.
+- It does not prove fleet-wide deployment or customer deployment.
+- It does not authorize AI-decided disposition, analyst-approved disposition, containment, closure, or suppression.
+- It does not mutate Lifetime Governed Cases.
+- It does not approve public publication.
+
+## Blocked Claims
+
+- public-safe runtime proof
+- production SOC operation
+- autonomous SOC operation
+- AI-decided disposition
+- analyst-approved disposition
+- Lifetime Governed Case mutation
+- broad ingestion
+- broad deployment
+- public publication approval
+
+## Human Review Boundary
+
+This record is source-controlled proof-boundary preservation only. Human governance review is still required before any public-safe candidate review, public wording change, release wording, website wording, LinkedIn wording, recruiter-facing wording, or stronger claim ceiling.
+
+Visible GitHub review activity may support governance traceability, but repository presence and CI checks do not promote this private candidate to public-safe proof.

--- a/scripts/verify-runtime-route-proof-v1-private-candidate-map.py
+++ b/scripts/verify-runtime-route-proof-v1-private-candidate-map.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Verify the Runtime Route Proof v1 private-candidate proof map boundary."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MAP_JSON = ROOT / "proof" / "indexes" / "runtime-route-proof-v1-private-candidate-map.json"
+MAP_MD = ROOT / "proof" / "indexes" / "runtime-route-proof-v1-private-candidate-map.md"
+RECORD_MD = ROOT / "proof" / "records" / "RUNTIME-ROUTE-PROOF-V1-PRIVATE-CANDIDATE.md"
+
+EXPECTED = {
+    "schema_version": "runtime-route-proof-v1-private-candidate-map-v1",
+    "map_id": "runtime-route-proof-v1-private-candidate-map",
+    "record_path": "proof/records/RUNTIME-ROUTE-PROOF-V1-PRIVATE-CANDIDATE.md",
+    "marker_id": "HO-RUNTIME-V1-20260601T120922Z-BATCH764",
+    "private_route": ["Wazuh", "Cribl", "Splunk"],
+    "deterministic_verifier_status": "PASS_ROUTE_RECEIPTS",
+    "manifest_verified": True,
+    "lifetime_governed_cases": 4,
+    "public_safe_count": 0,
+    "public_safe_status": "NOT_PUBLIC_SAFE",
+    "proof_ceiling": "PRIVATE_RUNTIME_ROUTE_PROOF_V1_CANDIDATE",
+    "preservation_ceiling": "PRIVATE_RUNTIME_ROUTE_PROOF_V1_CANDIDATE_PRESERVED",
+}
+
+EXPECTED_RECEIPTS = {
+    "wazuh": "PASS",
+    "cribl": "PASS",
+    "splunk": "PASS",
+}
+
+EXPECTED_PACKET = {
+    "filename": "HO-RUNTIME-ROUTE-PROOF-V1-PRIVATE-REVIEWER-SAFE-2026-06-01.zip",
+    "sha256": "3a1d4472bffcce68cff6e101c54e06b5a67528338bda174e6fef209fa9b1b278",
+    "raw_private_evidence_in_repo": False,
+}
+
+EXPECTED_BOUNDARY = {
+    "public_safe_runtime_proof": False,
+    "production_soc_operation": False,
+    "autonomous_soc_operation": False,
+    "ai_decided_disposition": False,
+    "lifetime_governed_case_mutation": False,
+    "public_publication_approved": False,
+    "human_review_required": True,
+}
+
+REQUIRED_MARKDOWN = (
+    "HO-RUNTIME-V1-20260601T120922Z-BATCH764",
+    "Wazuh -> Cribl -> Splunk",
+    "PASS_ROUTE_RECEIPTS",
+    "Manifest verified",
+    "Lifetime Governed Cases",
+    "Public-safe count",
+    "NOT_PUBLIC_SAFE",
+    "PRIVATE_RUNTIME_ROUTE_PROOF_V1_CANDIDATE_PRESERVED",
+    "AI-decided disposition",
+    "does not prove public-safe runtime proof",
+    "does not mutate Lifetime Governed Cases",
+)
+
+LEAK_PATTERNS = {
+    "windows_absolute_path": re.compile(r"\b[A-Z]:[\\/]"),
+    "unc_path": re.compile(r"\\\\[^\\\s]+\\[^\\\s]+"),
+    "lan_ip": re.compile(r"\b(?:10|172\.(?:1[6-9]|2\d|3[01])|192\.168)\.\d{1,3}\.\d{1,3}\b"),
+    "secret_assignment": re.compile(r"(?i)\b(secret|token|api[_-]?key|password|authorization|cookie)\s*[:=]\s*\S+"),
+    "raw_payload_label": re.compile(r"(?i)\b(raw_payload|command_line_raw|event_body_raw|full_log_raw)\b"),
+}
+
+PROMOTED_CLAIM_PATTERNS = {
+    "public_safe_approval": re.compile(r"(?i)\bPUBLIC_SAFE_APPROVED\b|\bpublic-safe approved\b"),
+    "production_soc": re.compile(r"(?i)\bPRODUCTION_SOC_PROVEN\b|\bproduction SOC operation proven\b"),
+    "autonomous_soc": re.compile(r"(?i)\bAUTONOMOUS_SOC_PROVEN\b|\bautonomous SOC operation proven\b"),
+    "ai_decided": re.compile(r"(?i)\bAI_DECIDED_DISPOSITION\s*[:=]\s*true\b"),
+    "lifetime_mutation": re.compile(r"(?i)\bLIFETIME_GOVERNED_CASE_CREATED\b|\blifetime_governed_case_mutation\s*[:=]\s*true\b"),
+}
+
+
+def fail(message: str) -> None:
+    print(f"runtime route proof v1 proof-map verification failed: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_json(path: Path) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON in {path.relative_to(ROOT)}: {exc}")
+    if not isinstance(data, dict):
+        fail(f"{path.relative_to(ROOT)} root must be an object")
+    return data
+
+
+def scan_text(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    for label, pattern in LEAK_PATTERNS.items():
+        if pattern.search(text):
+            fail(f"{label} pattern found in {path.relative_to(ROOT)}")
+    for label, pattern in PROMOTED_CLAIM_PATTERNS.items():
+        if pattern.search(text):
+            fail(f"{label} pattern found in {path.relative_to(ROOT)}")
+
+
+def assert_equal(actual, expected, label: str) -> None:
+    if actual != expected:
+        fail(f"{label} expected {expected!r} but got {actual!r}")
+
+
+def verify_markdown(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    normalized = text.lower()
+    for required in REQUIRED_MARKDOWN:
+        if required.lower() not in normalized:
+            fail(f"{path.relative_to(ROOT)} missing required boundary text: {required}")
+
+
+def verify() -> dict:
+    for path in (MAP_JSON, MAP_MD, RECORD_MD):
+        if not path.exists():
+            fail(f"missing required file: {path.relative_to(ROOT)}")
+        scan_text(path)
+
+    data = load_json(MAP_JSON)
+    for key, expected in EXPECTED.items():
+        assert_equal(data.get(key), expected, key)
+
+    assert_equal(data.get("receipts"), EXPECTED_RECEIPTS, "receipts")
+    assert_equal(data.get("reviewer_safe_packet"), EXPECTED_PACKET, "reviewer_safe_packet")
+    assert_equal(data.get("claim_boundary"), EXPECTED_BOUNDARY, "claim_boundary")
+
+    record_path = ROOT / data["record_path"]
+    if record_path != RECORD_MD:
+        fail("record_path must point to the private candidate record")
+
+    verify_markdown(MAP_MD)
+    verify_markdown(RECORD_MD)
+
+    blocked_claims = data.get("blocked_claims")
+    if not isinstance(blocked_claims, list) or "public-safe runtime proof" not in blocked_claims:
+        fail("blocked_claims must preserve public-safe runtime proof denial")
+
+    return {
+        "status": "PASS",
+        "map": str(MAP_JSON.relative_to(ROOT)),
+        "record": str(RECORD_MD.relative_to(ROOT)),
+        "marker_id": data["marker_id"],
+        "deterministic_verifier_status": data["deterministic_verifier_status"],
+        "manifest_verified": data["manifest_verified"],
+        "lifetime_governed_cases": data["lifetime_governed_cases"],
+        "public_safe_count": data["public_safe_count"],
+        "public_safe_status": data["public_safe_status"],
+        "raw_private_evidence_in_repo": data["reviewer_safe_packet"]["raw_private_evidence_in_repo"],
+        "ai_decided_disposition": data["claim_boundary"]["ai_decided_disposition"],
+    }
+
+
+def main() -> int:
+    print(json.dumps(verify(), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Preserves Runtime Route Proof v1 as a private candidate proof artifact with reviewer-safe facts only.

## Boundary

- Keeps `NOT_PUBLIC_SAFE` and `public_safe_count=0`.
- Preserves `Lifetime Governed Cases=4` without mutation.
- Does not claim public-safe runtime proof, production SOC operation, autonomous SOC behavior, AI-decided disposition, broad ingestion, or publication approval.
- Raw private runtime evidence remains outside the repo.

## Verification

- `python -B scripts/verify-runtime-route-proof-v1-private-candidate-map.py`
- `python -B scripts/verify_detection_proof_status_index.py`
- `python -B scripts/verify-ho-det-001-proof-integrity.py`
- `python -B scripts/verify_proof_integrity.py`
- `python -B scripts/verify-reviewer-proof-map.py --platform-root C:\Raylee\Repo\HawkinsOperations\hawkinsoperations-platform --github-root C:\Raylee\Repo\HawkinsOperations\.github`
- `python -B scripts/verify-reviewer-metrics-pipeline-closeout.py --format json`
- `git diff --check`